### PR TITLE
perf(messages): memoize MessageBubble + stabilize callbacks

### DIFF
--- a/app/features/chat/hooks/useStableCallback.ts
+++ b/app/features/chat/hooks/useStableCallback.ts
@@ -1,0 +1,17 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Returns a callback whose identity never changes but always invokes the
+ * latest version of `fn`. Use this to pass per-render closures to memoized
+ * children without busting their `React.memo` shallow comparison.
+ *
+ * Caveat: do NOT call the returned callback during the render of the
+ * component that created it — only from event handlers / effects.
+ */
+export function useStableCallback<TArgs extends unknown[], TReturn>(
+  fn: (...args: TArgs) => TReturn,
+): (...args: TArgs) => TReturn {
+  const ref = useRef(fn);
+  ref.current = fn;
+  return useCallback((...args: TArgs) => ref.current(...args), []);
+}

--- a/app/features/messages/components/MessageBubble.tsx
+++ b/app/features/messages/components/MessageBubble.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { memo, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { mdComponents } from '../markdownHelpers';
@@ -25,7 +25,7 @@ function getMessageCopyText(message: ChatMessage): string {
   return message.content || '';
 }
 
-export function MessageBubble({
+export const MessageBubble = memo(function MessageBubble({
   message,
   agents,
   failedSend,
@@ -48,10 +48,10 @@ export function MessageBubble({
   mounted: boolean;
   isCopied: boolean;
   isCopiedFormatted: boolean;
-  onCopy: () => void;
-  onCopyFormatted: (html: string, text: string) => void;
-  onToggleExpanded: () => void;
-  onRetryFailedSend: () => void;
+  onCopy: (messageId: string) => void;
+  onCopyFormatted: (messageId: string, html: string, text: string) => void;
+  onToggleExpanded: (messageId: string) => void;
+  onRetryFailedSend: (messageId: string) => void;
   onOpenImage: (src: string) => void;
   onAnswerAgentUserRequest: (requestId: string, response: AgentUserRequestResponse) => Promise<void>;
   onDismissAgentUserRequest: (requestId: string) => void;
@@ -65,7 +65,7 @@ export function MessageBubble({
     const node = ref.current;
     if (!node) {
       const fallback = getMessageCopyText(message);
-      onCopyFormatted('', fallback);
+      onCopyFormatted(message.id, '', fallback);
       return;
     }
     let htmlParts: string[] = [];
@@ -82,7 +82,7 @@ export function MessageBubble({
     }
     const html = htmlParts.join('\n');
     const text = textParts.join('\n').trim() || getMessageCopyText(message);
-    onCopyFormatted(html, text);
+    onCopyFormatted(message.id, html, text);
   };
 
   return (
@@ -129,11 +129,11 @@ export function MessageBubble({
                 )}
                 <div className={messageActionsClassName}>
                   {partsLong && !message.pending && (
-                    <button className="collapseToggle" onClick={onToggleExpanded}>
+                    <button className="collapseToggle" onClick={() => onToggleExpanded(message.id)}>
                       {isCollapsed ? 'Expand' : 'Collapse'}
                     </button>
                   )}
-                  <FailedSendActions message={message} failure={failedSend} onResend={() => onRetryFailedSend()} />
+                  <FailedSendActions message={message} failure={failedSend} onResend={() => onRetryFailedSend(message.id)} />
                   {message.type !== 'user' && (
                     <>
                       <button
@@ -141,7 +141,7 @@ export function MessageBubble({
                         className="messageCopyButton"
                         aria-label="Copy answer"
                         title="Copy answer"
-                        onClick={onCopy}
+                        onClick={() => onCopy(message.id)}
                       >
                         {isCopied ? 'Copied' : 'Copy'}
                       </button>
@@ -183,11 +183,11 @@ export function MessageBubble({
               )}
               <div className={messageActionsClassName}>
                 {isLong && (
-                  <button className="collapseToggle" onClick={onToggleExpanded}>
+                  <button className="collapseToggle" onClick={() => onToggleExpanded(message.id)}>
                     {isCollapsed ? 'Expand' : 'Collapse'}
                   </button>
                 )}
-                <FailedSendActions message={message} failure={failedSend} onResend={() => onRetryFailedSend()} />
+                <FailedSendActions message={message} failure={failedSend} onResend={() => onRetryFailedSend(message.id)} />
                 {message.type !== 'user' && (
                   <>
                     <button
@@ -195,7 +195,7 @@ export function MessageBubble({
                       className="messageCopyButton"
                       aria-label="Copy answer"
                       title="Copy answer"
-                      onClick={onCopy}
+                      onClick={() => onCopy(message.id)}
                     >
                       {isCopied ? 'Copied' : 'Copy'}
                     </button>
@@ -218,6 +218,6 @@ export function MessageBubble({
       )}
     </div>
   );
-}
+});
 
 export { getMessageCopyText };

--- a/app/features/messages/components/MessageList.tsx
+++ b/app/features/messages/components/MessageList.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Agent } from '../../agents/agentTypes';
 import type { ChatMessage, AgentUserRequestResponse } from '../../chat/chatTypes';
+import { useStableCallback } from '../../chat/hooks/useStableCallback';
 import type { FailedSendByMessageId } from '../messageTypes';
 import { MessageBubble, getMessageCopyText } from './MessageBubble';
 
@@ -35,7 +36,17 @@ export function MessageList({
     setMounted(true);
   }, []);
 
-  function handleCopy(message: ChatMessage) {
+  const messagesById = useMemo(() => {
+    const map = new Map<string, ChatMessage>();
+    for (const m of messages) map.set(m.id, m);
+    return map;
+  }, [messages]);
+  const messagesByIdRef = useRef(messagesById);
+  messagesByIdRef.current = messagesById;
+
+  const handleCopy = useStableCallback((messageId: string) => {
+    const message = messagesByIdRef.current.get(messageId);
+    if (!message) return;
     const text = getMessageCopyText(message);
     navigator.clipboard.writeText(text).then(() => {
       setCopiedMessageId(message.id);
@@ -45,9 +56,11 @@ export function MessageList({
     }).catch((err) => {
       console.error('Failed to copy message', err);
     });
-  }
+  });
 
-  function handleCopyFormatted(message: ChatMessage, html: string, text: string) {
+  const handleCopyFormatted = useStableCallback((messageId: string, html: string, text: string) => {
+    const message = messagesByIdRef.current.get(messageId);
+    if (!message) return;
     const flagCopied = () => {
       setCopiedFormattedMessageId(message.id);
       window.setTimeout(() => {
@@ -72,7 +85,14 @@ export function MessageList({
         console.error('Failed to copy message', err);
       });
     }
-  }
+  });
+
+  // Stabilize callback identities so React.memo on MessageBubble works.
+  const stableToggleExpanded = useStableCallback(onToggleExpanded);
+  const stableRetryFailedSend = useStableCallback(onRetryFailedSend);
+  const stableOpenImage = useStableCallback(onOpenImage);
+  const stableAnswerRequest = useStableCallback(onAnswerAgentUserRequest);
+  const stableDismissRequest = useStableCallback(onDismissAgentUserRequest);
 
   return (
     <>
@@ -86,13 +106,13 @@ export function MessageList({
           mounted={mounted}
           isCopied={copiedMessageId === message.id}
           isCopiedFormatted={copiedFormattedMessageId === message.id}
-          onCopy={() => handleCopy(message)}
-          onCopyFormatted={(html, text) => handleCopyFormatted(message, html, text)}
-          onToggleExpanded={() => onToggleExpanded(message.id)}
-          onRetryFailedSend={() => onRetryFailedSend(message.id)}
-          onOpenImage={onOpenImage}
-          onAnswerAgentUserRequest={onAnswerAgentUserRequest}
-          onDismissAgentUserRequest={onDismissAgentUserRequest}
+          onCopy={handleCopy}
+          onCopyFormatted={handleCopyFormatted}
+          onToggleExpanded={stableToggleExpanded}
+          onRetryFailedSend={stableRetryFailedSend}
+          onOpenImage={stableOpenImage}
+          onAnswerAgentUserRequest={stableAnswerRequest}
+          onDismissAgentUserRequest={stableDismissRequest}
         />
       ))}
     </>


### PR DESCRIPTION
Memoize MessageBubble and stabilize callback identities so typing in the composer no longer re-runs ReactMarkdown across every message on each keystroke.

## Root cause
- MessageBubble was not memoized, so it re-rendered on any parent state change.
- MessageList passed per-iteration arrow callbacks, which would defeat React.memo's shallow compare anyway.

## Fix
- Add useStableCallback (canonical useEvent pattern) for frozen-identity callbacks.
- Wrap MessageBubble in React.memo. Switch callback signatures to take messageId; the bubble binds message.id internally.
- In MessageList, build a messagesById map (fresh via ref) and stabilize all outgoing callbacks via useStableCallback. No more per-iteration arrows in the JSX.

## Verification
- tsc --noEmit clean
- npm run build clean