### PR TITLE
fix(systemd): pin npm absolute path in unit, drop start.sh wrapper

### DIFF
--- a/scripts/agents-chat.service
+++ b/scripts/agents-chat.service
@@ -12,7 +12,7 @@ WorkingDirectory=__PROJECT_DIR__
 
 # Load project env (KEY=VALUE per line). Leading '-' = file is optional.
 # Next.js also auto-loads .env.local at runtime; this line makes the same
-# values available to start.sh (PORT, LOG_DIR, etc.) before npm start runs.
+# values available to systemd / Node before the process starts.
 EnvironmentFile=-__PROJECT_DIR__/.env.local
 
 # Optional machine-level overrides (takes precedence over .env.local)
@@ -20,14 +20,15 @@ EnvironmentFile=-/etc/agents-chat.env
 
 Environment=NODE_ENV=production
 
-ExecStart=__SCRIPT_DIR__/start.sh --no-build
+# Absolute path required — systemd's PATH doesn't include nvm.
+# If npm lives elsewhere, override with: sudo systemctl edit agents-chat
+ExecStart=__NPM__ start
 
 Restart=on-failure
 RestartSec=10
 TimeoutStopSec=30
 KillSignal=SIGTERM
 
-# journald captures stdout/stderr in addition to start.sh's tee'd files
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=agents-chat

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,25 +40,45 @@ done
 (( EUID == 0 )) || { echo "Run with sudo (need systemctl access)." >&2; exit 1; }
 [[ -f "$unit_src" ]] || { echo "Missing unit template: $unit_src" >&2; exit 1; }
 
+command -v npm >/dev/null 2>&1 || {
+  echo "npm not found in root's PATH." >&2
+  echo "If you installed Node via nvm, the service won't find it either." >&2
+  echo "Install Node system-wide:" >&2
+  echo "  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -" >&2
+  echo "  sudo apt install -y nodejs" >&2
+  exit 1
+}
+
 user="$(id -un)"
 group="$(id -gn)"
+npm_bin="$(command -v npm)"
 
-# ── First-time install (renders the unit) ─────────────────────────────────────
+# ── Render unit (always — picks up template changes on every deploy) ──────────
 first_install=0
-if [[ ! -f "$unit_dest" ]]; then
-  first_install=1
+[[ -f "$unit_dest" ]] || first_install=1
+
+if (( first_install )); then
   echo "→ installing $service.service (user=$user)"
+else
+  echo "→ refreshing $service.service"
+fi
 
-  sed \
-    -e "s|__USER__|$user|g" \
-    -e "s|__GROUP__|$group|g" \
-    -e "s|__PROJECT_DIR__|$project_dir|g" \
-    -e "s|__SCRIPT_DIR__|$script_dir|g" \
-    "$unit_src" > "$unit_dest"
+rendered=$(sed \
+  -e "s|__USER__|$user|g" \
+  -e "s|__GROUP__|$group|g" \
+  -e "s|__PROJECT_DIR__|$project_dir|g" \
+  -e "s|__SCRIPT_DIR__|$script_dir|g" \
+  -e "s|__NPM__|$npm_bin|g" \
+  "$unit_src")
+
+if [[ ! -f "$unit_dest" ]] || ! diff -q <(echo "$rendered") "$unit_dest" >/dev/null 2>&1; then
+  echo "$rendered" > "$unit_dest"
   chmod 644 "$unit_dest"
-
-  mkdir -p logs .next .data
   systemctl daemon-reload
+fi
+
+if (( first_install )); then
+  mkdir -p logs .next .data
   systemctl enable "$service"
 fi
 


### PR DESCRIPTION
## Problem

The service was failing in a restart loop with:

```
agents-chat[…]: /home/azureuser/agents-chat/scripts/start.sh: line 59: exec: npm: not found
systemd[1]: agents-chat.service: Main process exited, code=exited, status=127/n/a
```

systemd-spawned processes get a minimal PATH (`/usr/bin:/bin`) that does not include nvm's `~/.nvm/versions/node/vX/bin`. The previous unit invoked `start.sh`, which itself ran `exec npm start` — same problem, one level deeper.

## Fix

- **`agents-chat.service`**: `ExecStart` is now `__NPM__ start`. `deploy.sh` resolves the absolute path via `command -v npm` and substitutes it during render. Removes the `start.sh` wrapper indirection entirely.
- **`deploy.sh`**: re-renders the unit on every deploy (not just first install) and only triggers `daemon-reload` when the rendered file actually changed. Existing deployments self-heal on the next `sudo ./scripts/deploy.sh`.
- **`deploy.sh`**: fails fast at the top with an actionable message if `npm` is not on the caller's PATH (includes the NodeSource install snippet).

## Operator note

Node must be installed system-wide (e.g. via NodeSource) so both `sudo ./scripts/deploy.sh` and the systemd service can resolve `npm`. nvm-only installs do not work — they live under a single user's `\C:\Users\wulei` and are invisible to root and systemd.

```bash
curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
sudo apt install -y nodejs
```

## Recovery for already-broken deployments

```bash
sudo systemctl stop agents-chat
# install Node system-wide (above)
cd /path/to/agents-chat
git pull
sudo ./scripts/deploy.sh        # re-renders the unit with /usr/bin/npm
```