### PR TITLE
fix: deploy.sh node detection and service configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --port 3010 --experimental-https",
     "build": "next build",
-    "start": "next start",
+    "start": "next start --port 3010",
     "start:prod": "next build && next start --port 3010"
   },
   "dependencies": {

--- a/scripts/agents-chat.service
+++ b/scripts/agents-chat.service
@@ -19,6 +19,7 @@ EnvironmentFile=-__PROJECT_DIR__/.env.local
 EnvironmentFile=-/etc/agents-chat.env
 
 Environment=NODE_ENV=production
+Environment=PATH=__NODE_BIN_DIR__:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Absolute path required — systemd's PATH doesn't include nvm.
 # If npm lives elsewhere, override with: sudo systemctl edit agents-chat
@@ -36,7 +37,7 @@ SyslogIdentifier=agents-chat
 # Light sandboxing
 NoNewPrivileges=true
 ProtectSystem=full
-ProtectHome=read-only
+ProtectHome=false
 PrivateTmp=true
 
 [Install]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,18 +40,71 @@ done
 (( EUID == 0 )) || { echo "Run with sudo (need systemctl access)." >&2; exit 1; }
 [[ -f "$unit_src" ]] || { echo "Missing unit template: $unit_src" >&2; exit 1; }
 
-command -v npm >/dev/null 2>&1 || {
-  echo "npm not found in root's PATH." >&2
-  echo "If you installed Node via nvm, the service won't find it either." >&2
-  echo "Install Node system-wide:" >&2
-  echo "  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -" >&2
-  echo "  sudo apt install -y nodejs" >&2
-  exit 1
+# ── Locate Node.js / npm ──────────────────────────────────────────────────────
+# When running via sudo, user-local version managers (nvm, fnm, volta) aren't
+# in root's PATH. We probe common install locations before giving up.
+_try_add_node_path() {
+  local dir="$1"
+  if [[ -d "$dir" && -x "$dir/node" && -x "$dir/npm" ]]; then
+    export PATH="$dir:$PATH"
+    return 0
+  fi
+  return 1
 }
+
+if ! command -v npm >/dev/null 2>&1; then
+  _home="${SUDO_USER:+/home/$SUDO_USER}"
+  [[ -z "$_home" ]] && _home="$HOME"
+  found=0
+
+  # 1) nvm — pick the highest installed version
+  _nvm_dir="$_home/.nvm/versions/node"
+  if [[ -d "$_nvm_dir" ]]; then
+    _latest=$(ls -v "$_nvm_dir" 2>/dev/null | tail -n1)
+    [[ -n "$_latest" ]] && _try_add_node_path "$_nvm_dir/$_latest/bin" && found=1
+  fi
+
+  # 2) fnm
+  if (( !found )); then
+    _fnm_dir="$_home/.local/share/fnm/node-versions"
+    if [[ -d "$_fnm_dir" ]]; then
+      _latest=$(ls -v "$_fnm_dir" 2>/dev/null | tail -n1)
+      [[ -n "$_latest" ]] && _try_add_node_path "$_fnm_dir/$_latest/installation/bin" && found=1
+    fi
+  fi
+
+  # 3) volta
+  if (( !found )); then
+    _volta_bin="$_home/.volta/bin"
+    _try_add_node_path "$_volta_bin" && found=1
+  fi
+
+  # 4) Common system-wide locations
+  if (( !found )); then
+    for _dir in /usr/local/bin /usr/bin /snap/node/current/bin; do
+      _try_add_node_path "$_dir" && { found=1; break; }
+    done
+  fi
+
+  command -v npm >/dev/null 2>&1 || {
+    echo "ERROR: npm not found." >&2
+    echo "" >&2
+    echo "Searched: nvm, fnm, volta, /usr/local/bin, /usr/bin, /snap/node/" >&2
+    echo "" >&2
+    echo "Install Node.js via one of:" >&2
+    echo "  • nvm:    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash" >&2
+    echo "  • fnm:    curl -fsSL https://fnm.vercel.app/install | bash" >&2
+    echo "  • volta:  curl https://get.volta.sh | bash" >&2
+    echo "  • system: curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt install -y nodejs" >&2
+    exit 1
+  }
+fi
+unset _try_add_node_path _home _nvm_dir _fnm_dir _volta_bin _latest _dir found
 
 user="$(id -un)"
 group="$(id -gn)"
 npm_bin="$(command -v npm)"
+node_bin_dir="$(dirname "$(command -v node)")"
 
 # ── Render unit (always — picks up template changes on every deploy) ──────────
 first_install=0
@@ -69,6 +122,7 @@ rendered=$(sed \
   -e "s|__PROJECT_DIR__|$project_dir|g" \
   -e "s|__SCRIPT_DIR__|$script_dir|g" \
   -e "s|__NPM__|$npm_bin|g" \
+  -e "s|__NODE_BIN_DIR__|$node_bin_dir|g" \
   "$unit_src")
 
 if [[ ! -f "$unit_dest" ]] || ! diff -q <(echo "$rendered") "$unit_dest" >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

The systemd service was crashing with `Cannot find module 'node:path'` because npm's shebang (`#!/usr/bin/env node`) resolved to the system's ancient Node.js v10 instead of the nvm-installed v22.

Additionally, `ProtectHome=read-only` prevented the app from writing logs and the SQLite database.

## Changes

- **`scripts/agents-chat.service`**: Add `PATH` environment variable (`__NODE_BIN_DIR__`) so systemd resolves the correct node binary; change `ProtectHome=read-only` → `false`
- **`scripts/deploy.sh`**: Multi-manager node detection (nvm, fnm, volta, system-wide) instead of only checking root's PATH; compute and render `node_bin_dir` into the service template
- **`package.json`**: Fix `start` script to use `--port 3010` (matching `dev` and `start:prod` conventions)

## Testing

Ran `sudo ./scripts/deploy.sh --no-pull --no-install --wait 30` from a clean state (service removed). Build succeeded, service started, health check passed on :3010.