### PR TITLE
fix: return JSON 401 for unauthenticated API requests

### DIFF
--- a/app/features/chat/chatApi.ts
+++ b/app/features/chat/chatApi.ts
@@ -7,6 +7,15 @@ export async function acpApi(body: Record<string, unknown>) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  if (res.status === 401) {
+    // Session expired — redirect to login
+    window.location.href = '/login';
+    return { ok: false, error: 'Session expired. Please sign in again.' };
+  }
+  const contentType = res.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    return { ok: false, error: `Unexpected response (${res.status}). Please refresh or sign in again.` };
+  }
   return res.json();
 }
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  apps: [{
+    name: 'agents-chat',
+    script: 'npm',
+    args: 'run start',
+    cwd: '/home/xujx/wa/agents-chat',
+    env: {
+      NODE_ENV: 'production',
+      npm_config_cache: '/home/xujx/.npm-user-cache',
+    },
+  }],
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,11 +2,37 @@ import { getToken } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+/**
+ * Derive the public-facing origin from reverse-proxy headers.
+ * Next.js middleware may see `request.url` as `https://localhost:3010/...`
+ * when behind nginx, so we reconstruct the correct origin from forwarded
+ * headers to build proper redirect URLs.
+ */
+function getPublicUrl(request: NextRequest): string {
+  const proto = request.headers.get('x-forwarded-proto') || 'https';
+  const host = request.headers.get('x-forwarded-host') || request.headers.get('host');
+  if (host) {
+    const pathname = request.nextUrl.pathname;
+    const search = request.nextUrl.search;
+    return `${proto}://${host}${pathname}${search}`;
+  }
+  return request.url;
+}
+
 export async function middleware(request: NextRequest) {
   const token = await getToken({ req: request, cookieName: 'next-auth.session-token' });
   if (!token) {
-    const loginUrl = new URL('/login', request.url);
-    loginUrl.searchParams.set('callbackUrl', request.url);
+    // For API routes, return 401 JSON instead of redirecting to login page.
+    // This prevents the client from receiving HTML when it expects JSON.
+    if (request.nextUrl.pathname.startsWith('/api/')) {
+      return NextResponse.json(
+        { ok: false, error: 'unauthenticated', message: 'Session expired. Please sign in again.' },
+        { status: 401 },
+      );
+    }
+    const publicUrl = getPublicUrl(request);
+    const loginUrl = new URL('/login', publicUrl);
+    loginUrl.searchParams.set('callbackUrl', publicUrl);
     return NextResponse.redirect(loginUrl);
   }
   return NextResponse.next();


### PR DESCRIPTION
Previously, the middleware redirected all unauthenticated requests (including API calls) to the HTML login page. When the client-side fetch expected JSON, it received HTML and threw:
  'Unexpected token <'

Changes:
- middleware.ts: API routes (/api/*) now get a JSON 401 response instead of an HTML redirect. Page requests use reconstructed public URL from forwarded headers (fixes localhost:3010 in callbackUrl when behind nginx).
- chatApi.ts: Handle 401 responses by redirecting to login. Handle non-JSON responses gracefully with a user-friendly error message.
- ecosystem.config.js: pm2 config with custom npm cache dir to avoid permission conflicts with root-owned cache entries.