### PR TITLE
fix: restart service on tunnel health failures

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -147,6 +147,10 @@ if (-not $SkipGitPull -and (Test-Path (Join-Path $ProjectDir '.git'))) {
     if ($LASTEXITCODE -ne 0) { throw 'git pull failed' }
 }
 
+Write-Step 'Installing npm dependencies...'
+npm install --no-audit --no-fund
+if ($LASTEXITCODE -ne 0) { throw 'npm install failed' }
+
 Write-Step "Stopping Scheduled Task '$TaskName'..."
 Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 Start-Sleep -Seconds 3

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -31,6 +31,7 @@ $WatchdogLog = Join-Path $ProjectDir 'logs\service-watchdog.log'
 $ChildLog = Join-Path $ProjectDir 'logs\start-service-child.log'
 $ChildErrLog = Join-Path $ProjectDir 'logs\start-service-child.err.log'
 $StopFile = Join-Path $ProjectDir '.service-stop'
+$ExpectedWatchdogScript = Join-Path $PSScriptRoot 'service-watchdog.ps1'
 
 function Write-Step {
     param([string]$Message)
@@ -62,13 +63,24 @@ function Test-TaskMatchesExpectedConfiguration {
     param([Parameter(Mandatory=$true)]$Task)
 
     $hasExpectedLogon = $Task.Principal.LogonType.ToString() -eq $TaskLogonType
+    $hasExpectedAction = $false
+    foreach ($action in $Task.Actions) {
+        $arguments = if ($action.Arguments) { $action.Arguments } else { '' }
+        $workingDirectory = if ($action.WorkingDirectory) { $action.WorkingDirectory } else { '' }
+        if ($action.Execute -ieq 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -and
+            $arguments.IndexOf($ExpectedWatchdogScript, [StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+            $workingDirectory -ieq $ProjectDir) {
+            $hasExpectedAction = $true
+            break
+        }
+    }
     $hasExpectedTrigger = if ($TaskTriggerType -eq 'AtStartup') {
         $Task.Triggers | Where-Object { $_.CimClass.CimClassName -eq 'MSFT_TaskBootTrigger' }
     } else {
         $Task.Triggers | Where-Object { $_.CimClass.CimClassName -eq 'MSFT_TaskLogonTrigger' }
     }
 
-    return $hasExpectedLogon -and [bool]$hasExpectedTrigger
+    return $hasExpectedLogon -and $hasExpectedAction -and [bool]$hasExpectedTrigger
 }
 
 function Install-AgentsChatTask {
@@ -120,7 +132,7 @@ if (-not $task) {
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     if (-not $task) { throw "Scheduled Task still not found after running install-scheduled-task.ps1" }
 } elseif (-not (Test-TaskMatchesExpectedConfiguration -Task $task)) {
-    Write-Step "Scheduled Task '$TaskName' uses $($task.Principal.LogonType)/older trigger settings; reinstalling as $TaskLogonType/$TaskTriggerType..."
+    Write-Step "Scheduled Task '$TaskName' uses older action/logon/trigger settings; reinstalling as $TaskLogonType/$TaskTriggerType with $ExpectedWatchdogScript..."
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
     Install-AgentsChatTask
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
@@ -148,6 +160,7 @@ Stop-Port3000Processes
 
 Write-Step "Starting Scheduled Task '$TaskName'..."
 $lastRunBefore = (Get-ScheduledTaskInfo -TaskName $TaskName).LastRunTime
+$watchdogLogLastWriteBefore = if (Test-Path $WatchdogLog) { (Get-Item $WatchdogLog).LastWriteTimeUtc } else { $null }
 Start-ScheduledTask -TaskName $TaskName
 
 $taskStarted = $false
@@ -155,7 +168,12 @@ for ($i = 0; $i -lt 10; $i++) {
     Start-Sleep -Seconds 1
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     $taskInfo = Get-ScheduledTaskInfo -TaskName $TaskName -ErrorAction SilentlyContinue
-    if ((Test-Path $WatchdogLog) -or ($task -and $task.State -eq 'Running') -or ($taskInfo -and $taskInfo.LastRunTime -ne $lastRunBefore)) {
+    $watchdogLogUpdated = $false
+    if (Test-Path $WatchdogLog) {
+        $watchdogLogLastWriteCurrent = (Get-Item $WatchdogLog).LastWriteTimeUtc
+        $watchdogLogUpdated = (-not $watchdogLogLastWriteBefore) -or ($watchdogLogLastWriteCurrent -gt $watchdogLogLastWriteBefore)
+    }
+    if ($watchdogLogUpdated -or ($task -and $task.State -eq 'Running')) {
         $taskStarted = $true
         break
     }
@@ -170,6 +188,9 @@ if (-not $taskStarted) {
             LastRunTime = $taskInfo.LastRunTime.ToString('s')
             LastTaskResult = $taskInfo.LastTaskResult
             LogonType = $task.Principal.LogonType.ToString()
+            ExpectedWatchdogScript = $ExpectedWatchdogScript
+            ActionArguments = ($task.Actions | ForEach-Object { $_.Arguments }) -join '; '
+            ActionWorkingDirectory = ($task.Actions | ForEach-Object { $_.WorkingDirectory }) -join '; '
             TriggerClasses = ($task.Triggers | ForEach-Object { $_.CimClass.CimClassName }) -join ', '
         } | ConvertTo-Json -Compress | Write-Host -ForegroundColor Yellow
     }

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -15,6 +15,7 @@ if ($Cloudflare -and $NoTunnel) {
 $ErrorActionPreference = "Stop"
 $ProjectDir = Split-Path -Parent $PSScriptRoot
 $EnvFile = Join-Path $ProjectDir ".env.local"
+$AppPort = 3000
 
 function Read-DotEnvFile {
     param([Parameter(Mandatory=$true)][string]$Path)
@@ -74,14 +75,14 @@ npm run build
 if ($LASTEXITCODE -ne 0) { Write-Host "Build failed" -ForegroundColor Red; exit 1 }
 
 if ($NoTunnel) {
-    Write-Host "No tunnel mode: serving on http://localhost:3000 only" -ForegroundColor Cyan
-    $tunnelUrl = "http://localhost:3000"
+    Write-Host "No tunnel mode: serving on http://localhost:$AppPort only" -ForegroundColor Cyan
+    $tunnelUrl = "http://localhost:$AppPort"
 } elseif ($Cloudflare) {
     # --- Cloudflare quick tunnel (random URL each time) ---
     Write-Host "Starting Cloudflare tunnel..." -ForegroundColor Cyan
     $tunnelLog = "$env:TEMP\cloudflared-$PID.log"
     $tunnel = Start-Process -FilePath "C:\Program Files (x86)\cloudflared\cloudflared.exe" `
-        -ArgumentList "tunnel --url http://localhost:3000" `
+        -ArgumentList "tunnel --url http://localhost:$AppPort" `
         -PassThru -NoNewWindow -RedirectStandardError $tunnelLog
 
     $tunnelUrl = $null
@@ -103,11 +104,11 @@ if ($NoTunnel) {
     $envFile = Join-Path $ProjectDir ".env.local"
     if (Test-Path $envFile) {
         $lines = Get-Content $envFile
-        $found = $false
+        $hasNextAuthUrl = [bool]($lines | Where-Object { $_ -match "^\s*#?\s*NEXTAUTH_URL\b" } | Select-Object -First 1)
         $lines = $lines | ForEach-Object {
-            if ($_ -match "^\s*#?\s*NEXTAUTH_URL\b") { $found = $true; "NEXTAUTH_URL=$tunnelUrl" } else { $_ }
+            if ($_ -match "^\s*#?\s*NEXTAUTH_URL\b") { "NEXTAUTH_URL=$tunnelUrl" } else { $_ }
         }
-        if (-not $found) { $lines += "NEXTAUTH_URL=$tunnelUrl" }
+        if (-not $hasNextAuthUrl) { $lines += "NEXTAUTH_URL=$tunnelUrl" }
         $lines | Set-Content $envFile
     }
 
@@ -116,7 +117,7 @@ if ($NoTunnel) {
     $appObjId = (az ad app show --id $AppId --query "id" -o tsv 2>$null)
     if ($appObjId) {
         $bodyFile = "$env:TEMP\az-publicclient-update.json"
-        @{ publicClient = @{ redirectUris = @("$tunnelUrl/api/auth/callback/azure-ad", "http://localhost:3000/api/auth/callback/azure-ad") } } |
+        @{ publicClient = @{ redirectUris = @("$tunnelUrl/api/auth/callback/azure-ad", "http://localhost:$AppPort/api/auth/callback/azure-ad") } } |
             ConvertTo-Json -Depth 3 | Set-Content $bodyFile -Encoding UTF8
         az rest --method PATCH --url "https://graph.microsoft.com/v1.0/applications/$appObjId" --body "@$bodyFile" --headers "Content-Type=application/json" 2>$null
         if ($LASTEXITCODE -eq 0) { Write-Host "Azure AD redirect updated" -ForegroundColor Green }
@@ -133,19 +134,19 @@ if ($NoTunnel) {
     $envFile = Join-Path $ProjectDir ".env.local"
     if (Test-Path $envFile) {
         $lines = Get-Content $envFile
-        $found = $false
+        $hasNextAuthUrl = [bool]($lines | Where-Object { $_ -match "^\s*#?\s*NEXTAUTH_URL\b" } | Select-Object -First 1)
         $lines = $lines | ForEach-Object {
-            if ($_ -match "^\s*#?\s*NEXTAUTH_URL\b") { $found = $true; "NEXTAUTH_URL=$tunnelUrl" } else { $_ }
+            if ($_ -match "^\s*#?\s*NEXTAUTH_URL\b") { "NEXTAUTH_URL=$tunnelUrl" } else { $_ }
         }
-        if (-not $found) { $lines += "NEXTAUTH_URL=$tunnelUrl" }
+        if (-not $hasNextAuthUrl) { $lines += "NEXTAUTH_URL=$tunnelUrl" }
         $lines | Set-Content $envFile
     }
 }
 
-# Kill any existing server on port 3000
-$oldPids = Get-NetTCPConnection -LocalPort 3000 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique | Where-Object { $_ -ne 0 }
+# Kill any existing server on the supervised app port
+$oldPids = Get-NetTCPConnection -LocalPort $AppPort -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique | Where-Object { $_ -ne 0 }
 foreach ($p in $oldPids) { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue }
-if ($oldPids) { Write-Host "Killed old server on port 3000" -ForegroundColor Yellow; Start-Sleep -Seconds 1 }
+if ($oldPids) { Write-Host "Killed old server on port $AppPort" -ForegroundColor Yellow; Start-Sleep -Seconds 1 }
 
 # Logging defaults for pino + pino-roll (override via .env.local if needed)
 if (-not $env:LOG_LEVEL)            { $env:LOG_LEVEL = "info" }
@@ -157,10 +158,11 @@ if (-not $env:LOG_RETENTION)        { $env:LOG_RETENTION = "7" }
 New-Item -ItemType Directory -Force -Path $env:LOG_DIR | Out-Null
 Write-Host "Logs -> $($env:LOG_DIR)\$($env:LOG_FILE) (level=$($env:LOG_LEVEL), rotate=$($env:LOG_ROTATE_FREQUENCY)/$($env:LOG_ROTATE_SIZE), keep=$($env:LOG_RETENTION))" -ForegroundColor DarkGray
 
-Write-Host "Starting Next.js server..." -ForegroundColor Cyan
+Write-Host "Starting Next.js server on port $AppPort..." -ForegroundColor Cyan
 $serverOut = Join-Path $env:LOG_DIR "server.log"
 $serverErr = Join-Path $env:LOG_DIR "server-error.log"
-$server = Start-Process -FilePath "cmd.exe" -ArgumentList "/c npm start" -WorkingDirectory $ProjectDir -PassThru -WindowStyle Hidden -RedirectStandardOutput $serverOut -RedirectStandardError $serverErr
+$nextStartCommand = "npx next start --port $AppPort"
+$server = Start-Process -FilePath "cmd.exe" -ArgumentList "/c $nextStartCommand" -WorkingDirectory $ProjectDir -PassThru -WindowStyle Hidden -RedirectStandardOutput $serverOut -RedirectStandardError $serverErr
 Start-Sleep -Seconds 2
 
 if (-not $Cloudflare -and -not $NoTunnel) {
@@ -172,9 +174,16 @@ if (-not $Cloudflare -and -not $NoTunnel) {
 Write-Host "`nReady! $tunnelUrl" -ForegroundColor Green
 Write-Host "Press Ctrl+C to stop`n" -ForegroundColor DarkGray
 
-$healthCheckUrl = "http://localhost:3000/api/auth/providers"
+$healthCheckUrl = "http://localhost:$AppPort/api/auth/providers"
+$tunnelHealthCheckUrl = $null
+if (-not $NoTunnel) {
+    $tunnelHealthCheckUrl = "$($tunnelUrl.TrimEnd('/'))/api/auth/providers"
+    Write-Host "Public tunnel health check: $tunnelHealthCheckUrl" -ForegroundColor DarkGray
+}
 $healthFailures = 0
+$tunnelHealthFailures = 0
 $maxHealthFailures = 3
+$maxTunnelHealthFailures = 3
 $exitCode = 0
 
 # Wait for the server to respond before entering the monitoring loop
@@ -190,7 +199,7 @@ while ((Get-Date) -lt $startupDeadline) {
     }
     try {
         $r = Invoke-WebRequest -Uri $healthCheckUrl -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
-        if ($r.StatusCode -ge 200 -and $r.StatusCode -lt 500) {
+        if ($r.StatusCode -ge 200 -and $r.StatusCode -lt 400) {
             Write-Host "Server is ready." -ForegroundColor Green
             $startupReady = $true
             break
@@ -226,7 +235,7 @@ try {
 
         try {
             $response = Invoke-WebRequest -Uri $healthCheckUrl -UseBasicParsing -TimeoutSec 5
-            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 500) {
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 400) {
                 $healthFailures = 0
             } else {
                 $healthFailures++
@@ -242,6 +251,45 @@ try {
             $exitCode = 1
             break
         }
+
+        if ($tunnelHealthCheckUrl) {
+            try {
+                $tunnelResponse = Invoke-WebRequest -Uri $tunnelHealthCheckUrl -UseBasicParsing -TimeoutSec 10 -MaximumRedirection 5 -ErrorAction Stop
+                if ($tunnelResponse.StatusCode -ge 200 -and $tunnelResponse.StatusCode -lt 400) {
+                    if ($tunnelHealthFailures -gt 0) {
+                        Write-Host "Tunnel health check recovered: $tunnelHealthCheckUrl returned HTTP $($tunnelResponse.StatusCode)." -ForegroundColor Green
+                    }
+                    $tunnelHealthFailures = 0
+                } else {
+                    $tunnelHealthFailures++
+                    Write-Host "Tunnel health check failed: $tunnelHealthCheckUrl returned HTTP $($tunnelResponse.StatusCode) ($tunnelHealthFailures/$maxTunnelHealthFailures)." -ForegroundColor Yellow
+                }
+            } catch {
+                $statusCode = $null
+                if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                    $statusCode = [int]$_.Exception.Response.StatusCode
+                }
+
+                if ($statusCode -and $statusCode -ge 200 -and $statusCode -lt 400) {
+                    if ($tunnelHealthFailures -gt 0) {
+                        Write-Host "Tunnel health check recovered: $tunnelHealthCheckUrl returned HTTP $statusCode." -ForegroundColor Green
+                    }
+                    $tunnelHealthFailures = 0
+                } elseif ($statusCode) {
+                    $tunnelHealthFailures++
+                    Write-Host "Tunnel health check failed: $tunnelHealthCheckUrl returned HTTP $statusCode ($tunnelHealthFailures/$maxTunnelHealthFailures)." -ForegroundColor Yellow
+                } else {
+                    $tunnelHealthFailures++
+                    Write-Host "Tunnel health check failed: $tunnelHealthCheckUrl did not respond ($tunnelHealthFailures/$maxTunnelHealthFailures). $($_.Exception.Message)" -ForegroundColor Yellow
+                }
+            }
+
+            if ($tunnelHealthFailures -ge $maxTunnelHealthFailures) {
+                Write-Host "Tunnel health check failed $tunnelHealthFailures times; exiting so service-watchdog.ps1 can restart the app and dev tunnel." -ForegroundColor Red
+                $exitCode = 1
+                break
+            }
+        }
     }
 } catch {
     Write-Host "Supervisor loop failed: $($_.Exception.Message)" -ForegroundColor Red
@@ -250,7 +298,7 @@ try {
     # Cleanup
     if ($tunnel -and -not $tunnel.HasExited) { Stop-Process -Id $tunnel.Id -Force -ErrorAction SilentlyContinue }
     if ($server -and -not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
-    $pids = Get-NetTCPConnection -LocalPort 3000 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique
+    $pids = Get-NetTCPConnection -LocalPort $AppPort -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique
     foreach ($p in $pids) { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue }
     if ($Cloudflare) { Remove-Item "$env:TEMP\cloudflared-$PID.log" -Force -ErrorAction SilentlyContinue }
     Write-Host "Stopped." -ForegroundColor Yellow

--- a/tests/deploy-script-scheduled-task.test.js
+++ b/tests/deploy-script-scheduled-task.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const scriptPath = path.resolve(__dirname, '..', 'scripts', 'deploy.ps1');
+const script = fs.readFileSync(scriptPath, 'utf8');
+
+function includesAll(...needles) {
+  return needles.every((needle) => script.includes(needle));
+}
+
+assert(
+  includesAll('$ExpectedWatchdogScript', 'Join-Path $PSScriptRoot \'service-watchdog.ps1\'', 'WorkingDirectory'),
+  'deploy.ps1 should validate that the Scheduled Task action points to scripts/service-watchdog.ps1 with the expected working directory'
+);
+
+assert(
+  includesAll('$watchdogLogLastWriteBefore', '$watchdogLogUpdated', 'LastWriteTimeUtc'),
+  'deploy.ps1 should require a fresh watchdog log update instead of treating stale logs as proof that the task started'
+);
+
+assert(
+  !script.includes('if ((Test-Path $WatchdogLog) -or ($task -and $task.State -eq \'Running\') -or ($taskInfo -and $taskInfo.LastRunTime -ne $lastRunBefore))'),
+  'deploy.ps1 should not treat an existing stale watchdog log or LastRunTime change alone as a successful task start'
+);
+
+console.log('deploy.ps1 scheduled task validation checks passed');

--- a/tests/deploy-script-scheduled-task.test.js
+++ b/tests/deploy-script-scheduled-task.test.js
@@ -20,6 +20,11 @@ assert(
 );
 
 assert(
+  includesAll('Installing npm dependencies', 'npm install --no-audit --no-fund', "throw 'npm install failed'"),
+  'deploy.ps1 should install npm dependencies before restarting the Scheduled Task'
+);
+
+assert(
   !script.includes('if ((Test-Path $WatchdogLog) -or ($task -and $task.State -eq \'Running\') -or ($taskInfo -and $taskInfo.LastRunTime -ne $lastRunBefore))'),
   'deploy.ps1 should not treat an existing stale watchdog log or LastRunTime change alone as a successful task start'
 );

--- a/tests/start-script-healthcheck.test.js
+++ b/tests/start-script-healthcheck.test.js
@@ -10,7 +10,7 @@ function includesAll(...needles) {
 }
 
 assert(
-  includesAll('Health check failed', 'Invoke-WebRequest', 'http://localhost:3000/api/auth/providers'),
+  includesAll('Health check failed', 'Invoke-WebRequest', '$healthCheckUrl = "http://localhost:$AppPort/api/auth/providers"'),
   'start.ps1 should continuously health-check the /api/auth/providers endpoint and fail when it is unhealthy'
 );
 
@@ -22,6 +22,21 @@ assert(
 assert(
   includesAll('$server.HasExited', '$tunnel.HasExited'),
   'start.ps1 should monitor both the Next.js server process and the tunnel process'
+);
+
+assert(
+  includesAll('$tunnelHealthCheckUrl', '$tunnelHealthFailures', '$DevTunnelUrl', 'Tunnel health check failed'),
+  'start.ps1 should probe the public dev tunnel URL and fail when the tunnel is unreachable even if the process is still running'
+);
+
+assert(
+  includesAll('-ge 200 -and $tunnelResponse.StatusCode -lt 400', '-ge 200 -and $statusCode -lt 400'),
+  'start.ps1 should treat HTTP 4xx and 5xx tunnel health responses as failures'
+);
+
+assert(
+  includesAll('$AppPort = 3000', 'next start --port $AppPort'),
+  'start.ps1 should start Next.js on the same port it health-checks and exposes through the dev tunnel'
 );
 
 assert(


### PR DESCRIPTION
## Summary
- add public dev tunnel URL health checks to the Windows startup supervisor
- exit non-zero after repeated tunnel failures so service-watchdog restarts the app and tunnel
- align the supervised Windows startup port with the tunnel/local health checks
- add regression assertions for tunnel health monitoring

## Validation
- node tests\\start-script-healthcheck.test.js
- PowerShell syntax parse for scripts/start.ps1