### PR TITLE
fix: polish chat composer controls

### DIFF
--- a/app/features/composer/components/ChatComposer.css
+++ b/app/features/composer/components/ChatComposer.css
@@ -239,6 +239,9 @@
 
 /* ── Orchestration pills / selects ── */
 .orchPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   cursor: pointer;
   border-color: var(--border);
   background: transparent;
@@ -261,6 +264,13 @@
 
 .orchPill.orchPillActive:hover {
   filter: brightness(1.08);
+}
+
+.workflowPillIcon {
+  color: inherit;
+  font-weight: 800;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  line-height: 1;
 }
 
 .orchRoundsSelect {
@@ -506,13 +516,24 @@
 }
 
 .stopButton {
-  background: linear-gradient(135deg, var(--danger), color-mix(in srgb, var(--danger) 76%, black 24%)) !important;
-  border-color: color-mix(in srgb, var(--danger) 58%, transparent) !important;
-  color: #fff !important;
+  background: color-mix(in srgb, var(--panel-strong) 88%, var(--danger) 12%) !important;
+  border-color: color-mix(in srgb, var(--danger) 48%, var(--border)) !important;
+  color: var(--danger) !important;
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--danger) 10%, transparent);
 }
 
 .stopButton:hover {
-  filter: brightness(1.08);
+  background: color-mix(in srgb, var(--panel-strong) 78%, var(--danger) 22%) !important;
+  filter: none;
+}
+
+.stopButtonIcon {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: currentColor;
+  display: block;
+  box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 10%, transparent);
 }
 
 /* ── Mobile overrides ── */
@@ -536,6 +557,10 @@
     min-width: 40px;
     height: 40px;
     min-height: 40px;
+  }
+
+  .stopButton {
+    box-shadow: none;
   }
 
   .mentionDropdown {

--- a/app/features/composer/components/ChatComposer.tsx
+++ b/app/features/composer/components/ChatComposer.tsx
@@ -147,7 +147,7 @@ export function ChatComposer({
               </div>
               <div className="composerActions composerToolbarActions">
                 {isSending
-                  ? <button className="sendButton stopButton" onClick={onStop} aria-label="Stop generation">⏹</button>
+                  ? <button className="sendButton stopButton" onClick={onStop} aria-label="Stop generation"><span className="stopButtonIcon" aria-hidden="true" /></button>
                   : <button className="sendButton" onClick={onSend} disabled={sendDisabled} aria-label="Send message">
                       <span className="sendButtonIcon">↑</span>
                     </button>

--- a/app/features/composer/components/ComposerTargetControls.tsx
+++ b/app/features/composer/components/ComposerTargetControls.tsx
@@ -51,7 +51,8 @@ export function ComposerTargetControls({
       onClick={onOpenWorkflowPicker}
       title="Workflow: pick a saved workflow or paste a JSON DAG to run"
     >
-      📋 {pendingWorkflowName ? `Workflow: ${pendingWorkflowName}` : 'Workflow'}
+      <span className="workflowPillIcon" aria-hidden="true">#</span>
+      <span>{pendingWorkflowName ? `Workflow: ${pendingWorkflowName}` : 'Workflow'}</span>
     </button>
   ) : null;
 

--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -501,19 +501,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.chatPageRoot .logoutBtn {
-  background: none;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  padding: 2px;
-  font-size: 14px;
-  line-height: 1;
-  transition: color 150ms;
-}
-.chatPageRoot .logoutBtn:hover {
-  color: var(--accent);
-}
 .chatPageRoot .userChip {
   position: relative;
 }

--- a/app/features/layout/components/PageHeader.tsx
+++ b/app/features/layout/components/PageHeader.tsx
@@ -282,7 +282,6 @@ export function PageHeader({
             >
               {authLabel}{isAdmin ? ' ★' : ''}
             </button>
-            <button className="logoutBtn" onClick={onSignOut} title="Sign out">↗</button>
             {showAccount && (
               <div className="accountMenu" role="dialog" aria-label="Account details">
                 <div className="accountMenuHeader">

--- a/app/features/orchestration/components/WorkflowPicker.css
+++ b/app/features/orchestration/components/WorkflowPicker.css
@@ -46,7 +46,14 @@
   background: var(--accent-soft);
   color: var(--accent);
 }
-.chatPageRoot .wfPickerItemName { font-size: 13px; font-weight: 500; }
+.chatPageRoot .wfPickerItemName {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 500;
+}
+.chatPageRoot .wfPickerItemIcon {
+  color: var(--accent); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px; font-weight: 800; line-height: 1;
+}
 .chatPageRoot .wfPickerItemMeta { font-size: 11px; color: var(--muted); }
 .chatPageRoot .wfPickerSection textarea {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/app/features/orchestration/components/WorkflowPicker.tsx
+++ b/app/features/orchestration/components/WorkflowPicker.tsx
@@ -83,7 +83,10 @@ export function WorkflowPicker({ open, onClose, onPicked, agentIds }: Props) {
             <div key={w.filePath} className="wfPickerItemRow">
               <button type="button" className="wfPickerItem"
                 onClick={() => { onPicked({ ...w.plan, name: w.name }); onClose(); }}>
-                <span className="wfPickerItemName">📋 {w.name}</span>
+                <span className="wfPickerItemName">
+                  <span className="wfPickerItemIcon" aria-hidden="true">#</span>
+                  <span>{w.name}</span>
+                </span>
                 <span className="wfPickerItemMeta">{w.plan.nodes.length} nodes</span>
               </button>
               <button type="button" className="wfPickerEditBtn" title="Edit this plan as JSON below"
@@ -98,7 +101,10 @@ export function WorkflowPicker({ open, onClose, onPicked, agentIds }: Props) {
             <div key={w.id} className="wfPickerItemRow">
               <button type="button" className="wfPickerItem"
                 onClick={() => { onPicked(w.plan); onClose(); }}>
-                <span className="wfPickerItemName">💾 {w.name}</span>
+                <span className="wfPickerItemName">
+                  <span className="wfPickerItemIcon" aria-hidden="true">#</span>
+                  <span>{w.name}</span>
+                </span>
                 <span className="wfPickerItemMeta">{w.plan.nodes.length} nodes</span>
               </button>
               <button type="button" className="wfPickerEditBtn" title="Edit this plan as JSON below"

--- a/test/account-details-popover.test.mjs
+++ b/test/account-details-popover.test.mjs
@@ -88,6 +88,11 @@ assert.match(
   /className="accountMenuSignOut"[\s\S]{0,120}onClick=\{\(\) => \{ setShowAccount\(false\); onSignOut\(\); \}\}/,
   'Account popover should offer a Sign out action that closes the popover',
 );
+assert.doesNotMatch(
+  headerSource,
+  /className="logoutBtn"/,
+  'The header user chip should not render a second sign-out button beside the account icon',
+);
 
 // 4. The popover closes on outside-click and Escape.
 assert.match(

--- a/test/composer-layout.test.mjs
+++ b/test/composer-layout.test.mjs
@@ -29,6 +29,16 @@ assert.ok(attachButtonIndex < attachIconIndex, 'file attachment button should in
 assert.doesNotMatch(shellSource.slice(attachButtonIndex, targetPillsIndex), /attachButtonLabel|>Files</, 'file attachment button should be icon-only');
 assert.ok(toolbarIndex < targetPillsIndex, 'agent/model target controls should live in the bottom toolbar');
 assert.ok(toolbarIndex < sendActionsIndex, 'send controls should live in the bottom toolbar');
+assert.match(
+	composerSource,
+	/aria-label="Stop generation">\s*<span className="stopButtonIcon" aria-hidden="true" \/>\s*<\/button>/,
+	'stop generation button should use a styled icon instead of a raw emoji glyph',
+);
+assert.doesNotMatch(
+	composerSource,
+	/>⏹<\/button>/,
+	'stop generation button should not render the heavy stop emoji glyph',
+);
 
 const textRowSource = shellSource.slice(textRowIndex, toolbarIndex);
 assert.doesNotMatch(textRowSource, /attachButton|targetControls|composerActions/, 'text row should contain only the textarea controls, not toolbar controls');
@@ -38,5 +48,15 @@ assert.match(composerCss, /\.composerTextRow\s*\{[\s\S]*?display:\s*flex;/, 'tex
 assert.match(composerCss, /\.attachmentTray\s*\{[\s\S]*?padding:\s*0 0 2px;/, 'attachment tray should sit as the compact top strip');
 assert.match(composerCss, /\.attachButton\s*\{[\s\S]*?width:\s*32px;[\s\S]*?border-radius:\s*999px;/, 'file attachment button should use a compact rounded icon-button shape');
 assert.doesNotMatch(composerCss, /\.attachButtonLabel\s*\{/, 'file attachment button should not include visible label styles');
+assert.match(
+	composerCss,
+	/\.stopButtonIcon\s*\{[\s\S]*?width:\s*10px;[\s\S]*?height:\s*10px;[\s\S]*?border-radius:\s*2px;/,
+	'stop generation icon should be a compact CSS square for stable mobile rendering',
+);
+assert.doesNotMatch(
+	composerCss,
+	/\.stopButton\s*\{[\s\S]*?linear-gradient\(135deg, var\(--danger\)/,
+	'stop generation button should not use the oversized danger gradient treatment',
+);
 
 console.log('composer layout checks passed');

--- a/test/workflow-icon-style.test.mjs
+++ b/test/workflow-icon-style.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const composerTargetControlsSource = readFileSync(
+  new URL('../app/features/composer/components/ComposerTargetControls.tsx', import.meta.url),
+  'utf8',
+);
+const workflowPickerSource = readFileSync(
+  new URL('../app/features/orchestration/components/WorkflowPicker.tsx', import.meta.url),
+  'utf8',
+);
+
+assert.match(
+  composerTargetControlsSource,
+  /<span className="workflowPillIcon" aria-hidden="true">#<\/span>/,
+  'Composer workflow pill should use a # icon like agent pills use @',
+);
+assert.doesNotMatch(
+  composerTargetControlsSource,
+  /📋\s*\{pendingWorkflowName/,
+  'Composer workflow pill should not use the clipboard emoji icon',
+);
+
+assert.match(
+  workflowPickerSource,
+  /<span className="wfPickerItemIcon" aria-hidden="true">#<\/span>/,
+  'Workflow picker rows should use the # workflow icon',
+);
+assert.doesNotMatch(
+  workflowPickerSource,
+  /📋|💾/,
+  'Workflow picker rows should not mix clipboard/save emoji icons for workflows',
+);
+
+console.log('workflow icon style checks passed');


### PR DESCRIPTION
## Summary
- use a # text icon for workflow pills and workflow picker rows to match @ agent pills
- remove the duplicate header sign-out icon while keeping sign out inside the account menu
- soften the mobile in-progress/stop composer button with a stable CSS icon

## Verification
- node test/composer-layout.test.mjs
- node test/account-details-popover.test.mjs
- node test/workflow-icon-style.test.mjs
- npm run build
- git diff --check