### PR TITLE
fix: compact mobile chat layout

### DIFF
--- a/app/features/composer/components/ChatComposer.css
+++ b/app/features/composer/components/ChatComposer.css
@@ -379,6 +379,7 @@
 .targetPill {
   display: inline-flex;
   align-items: center;
+  min-height: 28px;
   padding: 5px 10px;
   border-radius: 999px;
   border: 1px solid var(--border-strong);

--- a/app/features/composer/components/ChatComposer.css
+++ b/app/features/composer/components/ChatComposer.css
@@ -577,13 +577,46 @@
 
   .composerShell {
     width: 100%;
-    padding: 10px 12px;
+    padding: 9px 10px;
     border-radius: 12px;
   }
 
   .composerToolbar {
     gap: 8px;
     align-items: flex-end;
+  }
+
+  .composerToolbarLeft {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    gap: 6px;
+  }
+
+  .targetPills {
+    flex: 1 1 auto;
+    min-width: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 6px;
+    padding-bottom: 1px;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .targetPills::-webkit-scrollbar {
+    display: none;
+  }
+
+  .targetPill {
+    flex: 0 0 auto;
+    max-width: min(58vw, 220px);
+    padding: 5px 9px;
+    white-space: nowrap;
+  }
+
+  .modelTargetPill {
+    min-width: 0;
   }
 
   .composerTextarea {

--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -1110,22 +1110,52 @@
 
 @media (max-width: 560px) {
   .chatPageRoot .header {
-    gap: 12px;
+    flex-wrap: nowrap;
+    gap: 8px;
+    padding: 6px 10px;
+    min-height: 48px;
+  }
+  .chatPageRoot .headerLeft {
+    flex: 1 1 auto;
+    min-width: 0;
   }
   .chatPageRoot .header h1 {
-    font-size: 18px;
+    font-size: 16px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .chatPageRoot .headerRight {
-    gap: 8px;
+    flex: 0 0 auto;
+    gap: 6px;
+    min-width: 0;
+  }
+  .chatPageRoot .userChip {
+    gap: 5px;
+    padding: 3px 7px 3px 3px;
+  }
+  .chatPageRoot .userAvatar {
+    width: 22px;
+    height: 22px;
+    font-size: 11px;
+  }
+  .chatPageRoot .userName {
+    max-width: 76px;
   }
   .chatPageRoot .mobileOnlyButton {
-    min-height: 42px;
+    min-height: 36px;
   }
   .chatPageRoot .ghostButton,
   .chatPageRoot .themeMenuButton {
     min-height: unset;
-    padding: 6px 10px;
+    padding: 5px 9px;
     font-size: 14px;
+  }
+  .chatPageRoot .headerOverflowBtn {
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+    padding: 0;
   }
   .chatPageRoot .agentListItem {
     padding: 10px;

--- a/test/account-details-popover.test.mjs
+++ b/test/account-details-popover.test.mjs
@@ -129,5 +129,20 @@ assert.match(
   /\.chatPageRoot \.accountMenuSignOut:hover\s*\{[\s\S]*?color:\s*var\(--accent\)/,
   '.accountMenuSignOut:hover should use the themed accent color',
 );
+assert.match(
+  cssSource,
+  /@media \(max-width: 560px\) \{[\s\S]*?\.chatPageRoot \.header\s*\{[\s\S]*?flex-wrap:\s*nowrap;[\s\S]*?padding:\s*6px 10px;/,
+  'Mobile header should remain a compact single row',
+);
+assert.match(
+  cssSource,
+  /@media \(max-width: 560px\) \{[\s\S]*?\.chatPageRoot \.header h1\s*\{[\s\S]*?font-size:\s*16px;/,
+  'Mobile header title should use a smaller font size',
+);
+assert.match(
+  cssSource,
+  /@media \(max-width: 560px\) \{[\s\S]*?\.chatPageRoot \.userName\s*\{[\s\S]*?max-width:\s*76px;/,
+  'Mobile header should constrain the account name so controls fit on one row',
+);
 
 console.log('account-details-popover.test.mjs: all assertions passed');

--- a/test/composer-layout.test.mjs
+++ b/test/composer-layout.test.mjs
@@ -53,6 +53,16 @@ assert.match(
 	/\.stopButtonIcon\s*\{[\s\S]*?width:\s*10px;[\s\S]*?height:\s*10px;[\s\S]*?border-radius:\s*2px;/,
 	'stop generation icon should be a compact CSS square for stable mobile rendering',
 );
+assert.match(
+	composerCss,
+	/@media \(max-width: 560px\) \{[\s\S]*?\.targetPills\s*\{[\s\S]*?flex-wrap:\s*nowrap;[\s\S]*?overflow-x:\s*auto;/,
+	'mobile target pills should stay on one horizontally scrollable row instead of wrapping',
+);
+assert.match(
+	composerCss,
+	/@media \(max-width: 560px\) \{[\s\S]*?\.targetPill\s*\{[\s\S]*?white-space:\s*nowrap;/,
+	'mobile target pills should keep their labels on one line',
+);
 assert.doesNotMatch(
 	composerCss,
 	/\.stopButton\s*\{[\s\S]*?linear-gradient\(135deg, var\(--danger\)/,

--- a/test/composer-layout.test.mjs
+++ b/test/composer-layout.test.mjs
@@ -63,6 +63,11 @@ assert.match(
 	/@media \(max-width: 560px\) \{[\s\S]*?\.targetPill\s*\{[\s\S]*?white-space:\s*nowrap;/,
 	'mobile target pills should keep their labels on one line',
 );
+assert.match(
+	composerCss,
+	/\.targetPill\s*\{[\s\S]*?min-height:\s*28px;/,
+	'target pills should share a stable height whether or not they include a model selector',
+);
 assert.doesNotMatch(
 	composerCss,
 	/\.stopButton\s*\{[\s\S]*?linear-gradient\(135deg, var\(--danger\)/,


### PR DESCRIPTION
## Summary
- keep composer target pills on a single horizontally scrollable row on mobile
- compact the mobile header into one shorter row
- add regression coverage for mobile header and composer pill layout

## Verification
- node test/composer-layout.test.mjs
- node test/account-details-popover.test.mjs
- node test/workflow-icon-style.test.mjs
- npm run build
- git diff --check