### PR TITLE
fix: show mobile model picker menu

### DIFF
--- a/app/features/agents/components/AgentModelSelect.tsx
+++ b/app/features/agents/components/AgentModelSelect.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useLayoutEffect, useRef, useState, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import type { AgentModel } from '../agentTypes';
 
 interface AgentModelSelectProps {
@@ -23,15 +25,71 @@ export function AgentModelSelect({
   wrapRef,
   isEnsuring,
 }: AgentModelSelectProps) {
+  const localWrapRef = useRef<HTMLSpanElement | null>(null);
+  const [dropdownStyle, setDropdownStyle] = useState<CSSProperties | null>(null);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    function updatePosition() {
+      const wrap = localWrapRef.current;
+      if (!wrap) return;
+      const rect = wrap.getBoundingClientRect();
+      const minWidth = Math.max(180, rect.width);
+      const left = Math.min(Math.max(8, rect.left), window.innerWidth - minWidth - 8);
+      setDropdownStyle({
+        left,
+        bottom: Math.max(8, window.innerHeight - rect.top + 6),
+        minWidth,
+      });
+    }
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isOpen]);
+
   if (models.length === 0) return null;
   
   const selectedModel = models.find((model) => model.modelId === selectedModelId) || models[0];
   const selectedModelLabel = selectedModel?.name || selectedModel?.modelId || '';
+  const portalHost = typeof document !== 'undefined' ? document.querySelector('.chatPageRoot') || document.body : null;
+  const dropdown = isOpen && dropdownStyle ? (
+    <div
+      className="agentModelDropdown agentModelDropdownPortal"
+      role="listbox"
+      aria-label={`Model for ${agentId}`}
+      style={dropdownStyle}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      {models.map((model) => {
+        const isSelected = model.modelId === selectedModelId;
+        return (
+          <button
+            key={model.modelId}
+            type="button"
+            role="option"
+            aria-selected={isSelected}
+            className={`agentModelOption ${isSelected ? 'agentModelOptionActive' : ''}`}
+            title={model.description || model.modelId}
+            onClick={() => onSelectModel(model.modelId)}
+          >
+            <span className="agentModelOptionLabel">{model.name || model.modelId}</span>
+            {isSelected ? <span className="agentModelOptionCheck">✓</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
 
   return (
     <span
       className="agentModelSelectWrap"
-      ref={wrapRef}
+      ref={(el) => { localWrapRef.current = el; wrapRef?.(el); }}
     >
       <button
         type="button"
@@ -47,27 +105,7 @@ export function AgentModelSelect({
         <span className="agentModelSelectLabel">{selectedModelLabel}</span>
         <span className="agentModelSelectCaret" aria-hidden="true">▾</span>
       </button>
-      {isOpen && (
-        <div className="agentModelDropdown" role="listbox" aria-label={`Model for ${agentId}`}>
-          {models.map((model) => {
-            const isSelected = model.modelId === selectedModelId;
-            return (
-              <button
-                key={model.modelId}
-                type="button"
-                role="option"
-                aria-selected={isSelected}
-                className={`agentModelOption ${isSelected ? 'agentModelOptionActive' : ''}`}
-                title={model.description || model.modelId}
-                onClick={() => onSelectModel(model.modelId)}
-              >
-                <span className="agentModelOptionLabel">{model.name || model.modelId}</span>
-                {isSelected ? <span className="agentModelOptionCheck">✓</span> : null}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {dropdown && portalHost ? createPortal(dropdown, portalHost) : null}
     </span>
   );
 }

--- a/app/features/agents/components/AgentsPanel.css
+++ b/app/features/agents/components/AgentsPanel.css
@@ -232,6 +232,12 @@
   flex-direction: column;
   gap: 2px;
 }
+.chatPageRoot .agentModelDropdownPortal {
+  position: fixed;
+  top: auto;
+  right: auto;
+  bottom: auto;
+}
 .chatPageRoot .agentModelOption {
   display: flex;
   align-items: center;

--- a/test/agent-model-ui.test.mjs
+++ b/test/agent-model-ui.test.mjs
@@ -108,6 +108,28 @@ assert.match(
   'model selector should expose a stable test id for E2E coverage',
 );
 
+// 10b. Model dropdown is portaled so mobile horizontal pill scrolling cannot clip it.
+assert.match(
+  modelSelectSource,
+  /import \{ createPortal \} from 'react-dom';/,
+  'model dropdown should use a portal instead of rendering inside the scrollable target pills row',
+);
+assert.match(
+  modelSelectSource,
+  /const portalHost = typeof document !== 'undefined' \? document\.querySelector\('\.chatPageRoot'\) \|\| document\.body : null;/,
+  'model dropdown portal should render under .chatPageRoot so scoped dropdown styles still apply',
+);
+assert.match(
+  modelSelectSource,
+  /createPortal\(dropdown, portalHost\)/,
+  'model dropdown portal should render the dropdown into the resolved portal host',
+);
+assert.match(
+  modelSelectSource,
+  /onMouseDown=\{\(event\) => event\.stopPropagation\(\)\}/,
+  'portaled model dropdown should stop mousedown propagation so outside-click handling does not close it before option clicks',
+);
+
 // 11. Model selector CSS — base styles (border, background, cursor).
 assert.match(
   cssBlock('.agentModelSelect'),
@@ -148,6 +170,13 @@ assert.doesNotMatch(
   cssBlock('.agentModelSelect'),
   /%2345d7ff|color:\s*var\(--accent\)/,
   'model selector must not hard-code the Aurora accent or override the target pill color',
+);
+
+// 17. Portaled dropdown CSS — fixed positioning escapes mobile overflow clipping.
+assert.match(
+  cssBlock('.agentModelDropdownPortal'),
+  /position:\s*fixed;[\s\S]*?bottom:\s*auto;/,
+  'portaled model dropdown should use fixed positioning and avoid inherited absolute bottom placement',
 );
 
 console.log('agent model UI checks passed');


### PR DESCRIPTION
## Summary
- render the agent model dropdown through a portal so mobile composer pill overflow cannot clip it
- keep the portal under .chatPageRoot so existing scoped dropdown styles still apply
- add regression coverage for the portaled model picker menu

## Verification
- node test/agent-model-ui.test.mjs
- node test/composer-layout.test.mjs
- npm run build
- git diff --check