### PR TITLE
test: update stale Playwright selectors

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,9 +13,21 @@ permissions:
 
 jobs:
   playwright:
-    name: Run Playwright tests
+    name: Run Playwright tests (${{ matrix.shard.index }}/${{ matrix.shard.total }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - index: 1
+            total: 4
+          - index: 2
+            total: 4
+          - index: 3
+            total: 4
+          - index: 4
+            total: 4
 
     env:
       ADMIN_PASSWORD: admin123
@@ -66,13 +78,13 @@ jobs:
           exit 1
 
       - name: Run Playwright tests
-        run: npx playwright test --config tests/playwright.config.ts
+        run: npx playwright test --config tests/playwright.config.ts --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
 
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-artifacts
+          name: playwright-artifacts-${{ matrix.shard.index }}
           path: |
             playwright-report/
             test-results/

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
   playwright:
     name: Run Playwright tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
 
     env:
       ADMIN_PASSWORD: admin123

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,12 +22,16 @@ jobs:
         shard:
           - index: 1
             total: 4
+            parts: 1 5 9 13
           - index: 2
             total: 4
+            parts: 2 6 10 14
           - index: 3
             total: 4
+            parts: 3 7 11 15
           - index: 4
             total: 4
+            parts: 4 8 12 16
 
     env:
       ADMIN_PASSWORD: admin123
@@ -78,7 +82,10 @@ jobs:
           exit 1
 
       - name: Run Playwright tests
-        run: npx playwright test --config tests/playwright.config.ts --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
+        run: |
+          for shard in ${{ matrix.shard.parts }}; do
+            npx playwright test --config tests/playwright.config.ts --shard="$shard/16"
+          done
 
       - name: Upload Playwright artifacts
         if: failure()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,9 +14,7 @@ permissions:
 jobs:
   playwright:
     name: Run Playwright tests
-    # GitHub-hosted runners are disabled for this repository.
-    # Register a Windows x64 self-hosted runner with the mwc-wulei label.
-    runs-on: [self-hosted, Windows, X64, mwc-wulei]
+    runs-on: windows-latest
     timeout-minutes: 30
 
     env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   playwright:
     name: Run Playwright tests
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:
@@ -38,36 +38,31 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Start Next.js dev server
-        shell: pwsh
+        shell: bash
         run: |
-          $process = Start-Process npm -ArgumentList 'run', 'dev' -RedirectStandardOutput playwright-server.log -RedirectStandardError playwright-server.err.log -PassThru
-          $process.Id | Out-File -FilePath playwright-server.pid -Encoding ascii
+          nohup npm run dev >playwright-server.log 2>playwright-server.err.log &
+          echo "$!" > playwright-server.pid
 
       - name: Wait for app
-        shell: pwsh
+        shell: bash
         run: |
-          $pidPath = 'playwright-server.pid'
-          for ($attempt = 1; $attempt -le 60; $attempt++) {
-            try {
-              Invoke-WebRequest -Uri "$env:PLAYWRIGHT_BASE_URL/login" -UseBasicParsing -SkipCertificateCheck -TimeoutSec 5 | Out-Null
+          server_pid="$(cat playwright-server.pid)"
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --show-error --insecure "$PLAYWRIGHT_BASE_URL/login" >/dev/null; then
               exit 0
-            } catch {
-              $serverPid = [int](Get-Content $pidPath -Raw)
-              if (-not (Get-Process -Id $serverPid -ErrorAction SilentlyContinue)) {
-                Write-Error 'Next.js dev server exited before becoming ready.'
-                Get-Content playwright-server.log -ErrorAction SilentlyContinue
-                Get-Content playwright-server.err.log -ErrorAction SilentlyContinue
-                exit 1
-              }
-              Start-Sleep -Seconds 2
-            }
-          }
-          Write-Error "Timed out waiting for $env:PLAYWRIGHT_BASE_URL/login"
-          Get-Content playwright-server.log -ErrorAction SilentlyContinue
-          Get-Content playwright-server.err.log -ErrorAction SilentlyContinue
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo 'Next.js dev server exited before becoming ready.' >&2
+              cat playwright-server.log playwright-server.err.log 2>/dev/null || true
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Timed out waiting for $PLAYWRIGHT_BASE_URL/login" >&2
+          cat playwright-server.log playwright-server.err.log 2>/dev/null || true
           exit 1
 
       - name: Run Playwright tests

--- a/app/features/chat/runtime/chatAcpService.ts
+++ b/app/features/chat/runtime/chatAcpService.ts
@@ -29,6 +29,7 @@ export type AcpServiceContext = {
   removeMessage: (id: string, chatId?: string) => void;
   notifyRunStateChanged: () => void;
   maybeAdvanceOrchestration: (orchestrationId: string) => Promise<void>;
+  onRunFinalized?: (chatId: string) => void;
   fileCommentCallbacksRef: MutableRefObject<FileCommentCallbacks | null>;
 };
 
@@ -57,6 +58,7 @@ export function createAcpHandlers(ctx: AcpServiceContext) {
     }
     delete ctx.sessionRunsRef.current[runKey];
     ctx.notifyRunStateChanged();
+    ctx.onRunFinalized?.(run.chatId);
     if (orchestration && run.kind === 'worker') {
       void ctx.maybeAdvanceOrchestration(run.orchestrationId);
     }

--- a/app/features/chat/runtime/chatOrchestrationService.ts
+++ b/app/features/chat/runtime/chatOrchestrationService.ts
@@ -22,6 +22,7 @@ export type OrchestrationContext = {
   addMessage: (msg: any, chatId?: string) => string;
   removeMessage: (id: string, chatId?: string) => void;
   notifyRunStateChanged: () => void;
+  persistChat?: (chatId: string) => void;
 };
 
 export function createOrchestrationHandlers(ctx: OrchestrationContext) {
@@ -49,7 +50,15 @@ export function createOrchestrationHandlers(ctx: OrchestrationContext) {
       await ctx.dispatchToAgent(agentId, prompt, orchestrationId, kind, options);
       return true;
     } catch (err) {
-      if (markOrchestrationPromptSendFailed(orchestrationId, err)) return false;
+      const chatId = ctx.orchestrationsRef.current[orchestrationId]?.sourceChatId;
+      const runKeys = Object.entries(ctx.sessionRunsRef.current)
+        .filter(([, run]) => run.orchestrationId === orchestrationId)
+        .map(([runKey]) => runKey);
+      if (markOrchestrationPromptSendFailed(orchestrationId, err)) {
+        await cleanupDispatchedRuns(runKeys);
+        if (chatId) ctx.persistChat?.(chatId);
+        return false;
+      }
       throw err;
     }
   }

--- a/app/features/chat/runtime/useChatRuntime.ts
+++ b/app/features/chat/runtime/useChatRuntime.ts
@@ -153,12 +153,14 @@ export function useChatRuntime({
   }
 
   /* ── ACP service ── */
+  const saveChatToHistoryRef = useRef<(chatId: string) => Promise<number>>(async () => Date.now());
   const acpHandlers = createAcpHandlers({
     acp, sessionRunsRef, orchestrationsRef, currentChatIdRef, currentAgentSessionsRef,
     needsContextRestoreRef, chatMessagesRef, messagesRef, agentsRef,
     getSelectedModelIdForAgent,
     updateMessage, addMessage, removeMessage, notifyRunStateChanged,
     maybeAdvanceOrchestration: (id) => maybeAdvanceOrchestrationRef.current(id),
+    onRunFinalized: (chatId) => { void saveChatToHistoryRef.current(chatId); },
     fileCommentCallbacksRef,
   });
 
@@ -170,6 +172,7 @@ export function useChatRuntime({
       dispatchToAgentRef.current(agentId, content, orchestrationId, kind, options),
     markUserMessageSendFailed,
     addMessage, removeMessage, notifyRunStateChanged,
+    persistChat: (chatId) => { void saveChatToHistoryRef.current(chatId); },
   });
 
   /* ── Wire cross-service refs ── */
@@ -195,6 +198,7 @@ export function useChatRuntime({
     prepareResume: (chatId) => hydrateOrchestrationsForChatRef.current(chatId),
     finalizeResume: (chatId) => reconcileRunningWorkflowNodesRef.current(chatId),
   });
+  saveChatToHistoryRef.current = persistHandlers.saveChatToHistory;
 
   /* ── Orchestration hydration ── */
   // Load persisted orchestrations into memory AS-IS. We deliberately keep

--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -712,6 +712,8 @@
 }
 .chatPageRoot .modal {
   width: min(520px, 100%);
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
   background: var(--panel-strong);
   border: 1px solid var(--border);
   border-radius: 20px;

--- a/app/features/scheduler/components/AgentPicker.tsx
+++ b/app/features/scheduler/components/AgentPicker.tsx
@@ -39,6 +39,7 @@ export function AgentPicker({ agents, value, disabled, onChange }: AgentPickerPr
         className={`themedPickerTrigger ${open ? 'themedPickerOpen' : ''}`}
         aria-haspopup="listbox"
         aria-expanded={open}
+        data-value={value}
         disabled={disabled}
         onClick={() => setOpen((p) => !p)}
       >
@@ -59,6 +60,7 @@ export function AgentPicker({ agents, value, disabled, onChange }: AgentPickerPr
                   role="option"
                   aria-selected={isSelected}
                   className={`themedPickerOption ${isSelected ? 'themedPickerOptionActive' : ''}`}
+                  data-value={a.id}
                   onClick={() => { onChange(a.id); setOpen(false); }}
                   title={`@${a.id}`}
                 >

--- a/app/features/scheduler/components/ScheduleEditor.tsx
+++ b/app/features/scheduler/components/ScheduleEditor.tsx
@@ -55,7 +55,7 @@ export function ScheduleEditor({ jobId, agents, onClose, onSaved }: ScheduleEdit
       setPrompt('');
       setEnabled(true);
       setSpecKind('every_minutes');
-      setEveryMinutesInterval(60);
+      setEveryMinutesInterval(30);
       setTimeoutMinutes(DEFAULT_TIMEOUT_MINUTES);
       setError(null);
     } else {

--- a/app/features/ui/SelectPicker.tsx
+++ b/app/features/ui/SelectPicker.tsx
@@ -52,6 +52,7 @@ export function SelectPicker<V extends string = string>({
       <button
         type="button"
         className={`themedPickerTrigger ${open ? 'themedPickerOpen' : ''}`}
+        data-value={value}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={ariaLabel}
@@ -73,6 +74,7 @@ export function SelectPicker<V extends string = string>({
                   key={o.value}
                   type="button"
                   role="option"
+                  data-value={o.value}
                   aria-selected={isSelected}
                   className={`themedPickerOption ${isSelected ? 'themedPickerOptionActive' : ''}`}
                   onClick={() => { onChange(o.value); setOpen(false); }}

--- a/tests/agent-composer-default-model.spec.ts
+++ b/tests/agent-composer-default-model.spec.ts
@@ -20,11 +20,29 @@ async function login(page: Page) {
 }
 
 async function ensureActiveChat(page: Page) {
-  const isEmpty = await page.locator('.emptyHomepage').isVisible({ timeout: 3000 }).catch(() => false);
-  if (isEmpty) {
-    await page.locator('button.newChatButton, button.emptyHomepageNewChat').first().click();
-    await page.waitForSelector('.chatContainer', { timeout: 10000 });
+  await page.locator('button.emptyHomepageNewChat').click();
+  await page.waitForSelector('.chatContainer', { timeout: 10000 });
+}
+
+async function resetChats(page: Page) {
+  const chats = await page.evaluate(async () => {
+    const response = await fetch('/api/chats');
+    return response.json();
+  });
+  for (const chat of chats.chats || []) {
+    await page.evaluate(async (chatId) => {
+      await fetch(`/api/chats?id=${encodeURIComponent(chatId)}`, { method: 'DELETE' });
+    }, chat.id);
   }
+  await page.evaluate(async () => {
+    await fetch('/api/chats', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'set-last-chat', chatId: '' }),
+    });
+  });
+  await page.reload();
+  await page.waitForSelector('.emptyHomepage', { timeout: 30000 });
 }
 
 test('composer model picker saves the selected model as a user preference', async ({ page }) => {
@@ -104,6 +122,7 @@ test('composer model picker saves the selected model as a user preference', asyn
   });
 
   await login(page);
+  await resetChats(page);
   await ensureActiveChat(page);
   await page.waitForTimeout(500);
 

--- a/tests/agent-composer-default-model.spec.ts
+++ b/tests/agent-composer-default-model.spec.ts
@@ -107,7 +107,7 @@ test('composer model picker saves the selected model as a user preference', asyn
   await ensureActiveChat(page);
   await page.waitForTimeout(500);
 
-  const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+  const textarea = page.locator('textarea.composerTextarea');
   await textarea.fill('@alpha use composer default model');
 
   await expectModelPickerSelection(page, 'alpha', 'Claude Sonnet 4.6');

--- a/tests/agent-composer-ensure-models.spec.ts
+++ b/tests/agent-composer-ensure-models.spec.ts
@@ -73,7 +73,7 @@ test('composer creates a chat-bound session to populate empty agent models', asy
   await login(page);
   await ensureActiveChat(page);
 
-  const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+  const textarea = page.locator('textarea.composerTextarea');
   await textarea.fill('@alpha discover models before sending');
 
   await expect.poll(() => ensureRequests.map((request) => `${request.agentId}:${request.chatId}`)).toEqual([`alpha:${seenChatId}`]);

--- a/tests/agent-composer-ensure-models.spec.ts
+++ b/tests/agent-composer-ensure-models.spec.ts
@@ -20,8 +20,29 @@ async function login(page: Page) {
 }
 
 async function ensureActiveChat(page: Page) {
-  await page.locator('button.newChatButton, button.emptyHomepageNewChat').first().click();
+  await page.locator('button.emptyHomepageNewChat').click();
   await page.waitForSelector('.chatContainer', { timeout: 10000 });
+}
+
+async function resetChats(page: Page) {
+  const chats = await page.evaluate(async () => {
+    const response = await fetch('/api/chats');
+    return response.json();
+  });
+  for (const chat of chats.chats || []) {
+    await page.evaluate(async (chatId) => {
+      await fetch(`/api/chats?id=${encodeURIComponent(chatId)}`, { method: 'DELETE' });
+    }, chat.id);
+  }
+  await page.evaluate(async () => {
+    await fetch('/api/chats', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'set-last-chat', chatId: '' }),
+    });
+  });
+  await page.reload();
+  await page.waitForSelector('.emptyHomepage', { timeout: 30000 });
 }
 
 test('composer creates a chat-bound session to populate empty agent models', async ({ page }) => {
@@ -71,6 +92,7 @@ test('composer creates a chat-bound session to populate empty agent models', asy
   });
 
   await login(page);
+  await resetChats(page);
   await ensureActiveChat(page);
 
   const textarea = page.locator('textarea.composerTextarea');

--- a/tests/agent-model-selection-video.spec.ts
+++ b/tests/agent-model-selection-video.spec.ts
@@ -121,7 +121,7 @@ test('records selecting per-agent ACP models and sending selected modelId', asyn
   await ensureActiveChat(page);
   await page.waitForTimeout(700);
 
-  const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+  const textarea = page.locator('textarea.composerTextarea');
   await textarea.fill('@alpha compare models for this task');
   await expect(page.locator('[data-testid="agent-model-select"]')).toHaveCount(1);
 

--- a/tests/agent-model-style-debug.spec.ts
+++ b/tests/agent-model-style-debug.spec.ts
@@ -13,8 +13,8 @@ async function login(page: Page) {
 async function ensureActiveChat(page: Page) {
   const isEmpty = await page.locator('.emptyHomepage').isVisible({ timeout: 3000 }).catch(() => false);
   if (isEmpty) {
-    await page.locator('button.newChatButton, button.emptyHomepageNewChat').first().click();
-    await page.waitForSelector('.chatContainer', { timeout: 10000 });
+    await page.locator('button.emptyHomepageNewChat').click();
+    await page.waitForSelector('.chatContainer', { timeout: 30000 });
   }
 }
 
@@ -40,6 +40,24 @@ test('debug model select computed styles', async ({ page }) => {
   });
 
   await login(page);
+  const chats = await page.evaluate(async () => {
+    const response = await fetch('/api/chats');
+    return response.json();
+  });
+  for (const chat of chats.chats || []) {
+    await page.evaluate(async (chatId) => {
+      await fetch(`/api/chats?id=${encodeURIComponent(chatId)}`, { method: 'DELETE' });
+    }, chat.id);
+  }
+  await page.evaluate(async () => {
+    await fetch('/api/chats', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'set-last-chat', chatId: '' }),
+    });
+  });
+  await page.reload();
+  await page.waitForSelector('.emptyHomepage', { timeout: 30000 });
   await ensureActiveChat(page);
   await page.locator('textarea.composerTextarea').fill('@alpha compare models');
   await expect(page.locator('[data-testid="agent-model-select"]')).toHaveCount(1);

--- a/tests/agent-model-style-debug.spec.ts
+++ b/tests/agent-model-style-debug.spec.ts
@@ -41,7 +41,7 @@ test('debug model select computed styles', async ({ page }) => {
 
   await login(page);
   await ensureActiveChat(page);
-  await page.locator('textarea[placeholder="Message Agents Chat"]').fill('@alpha compare models');
+  await page.locator('textarea.composerTextarea').fill('@alpha compare models');
   await expect(page.locator('[data-testid="agent-model-select"]')).toHaveCount(1);
   const styles = await page.locator('.modelTargetPill').evaluate((pill) => {
     const select = pill.querySelector('[data-testid="agent-model-select"]') as HTMLSelectElement;

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: '.',
   testMatch: '**/*.spec.ts',
+  fullyParallel: true,
   timeout: 180000,
   retries: 0,
   workers: 1,

--- a/tests/test-file-comments.spec.ts
+++ b/tests/test-file-comments.spec.ts
@@ -1235,7 +1235,7 @@ test.describe('File Comments UI', () => {
       await commentCard.click();
       await commentCard.getByRole('button', { name: 'View chat' }).click();
 
-      await expect(page.locator('textarea[placeholder="Message Agents Chat"]')).toBeVisible();
+      await expect(page.locator('textarea.composerTextarea')).toBeVisible();
       await expect(page.locator('.message.agent', { hasText: 'Resolved review chat content' })).toBeVisible();
     } finally {
       await page.evaluate(async (reviewChatId: string) => {
@@ -1934,7 +1934,7 @@ test.describe('File Comments UI', () => {
       await page.locator('.mdTreeFile', { hasText: filePath }).click();
       await page.click('button.leftSidebarTab:has-text("Chats")');
       await page.click('button.chatHistoryItem:has-text("Review: ui-legacy-review.md")');
-      await page.fill('textarea[placeholder="Message Agents Chat"]', 'finish legacy review run');
+      await page.fill('textarea.composerTextarea', 'finish legacy review run');
       await page.click('button[aria-label="Send message"]');
 
       await expect.poll(() => resolvedCommentIds).toContain(commentId);
@@ -2467,7 +2467,7 @@ test.describe('File Comments UI', () => {
     await page.click('button[type="submit"]');
 
     await expect(page.locator('.leftSidebarTab.active')).toContainText('Files');
-    await expect(filesAgentTrigger(page)).toHaveValue('restore-agent');
+    await expect(filesAgentTrigger(page)).toHaveAttribute('data-value', 'restore-agent');
     await expect(page.locator('.mdEditorFilePath')).toContainText('restore.md');
     await expect(page.locator('.mdModeBtn').filter({ hasText: /^Review$/ })).toHaveCount(0);
     await expect(page.locator('.mdModeBtn.active')).toHaveText('Live Edit');
@@ -2694,7 +2694,7 @@ test.describe('File Comments UI', () => {
     await page.click('button.leftSidebarTab:has-text("Chats")');
     await page.click('button.chatHistoryItem:has-text("Switch Back Chat")');
 
-    await expect(page.locator('textarea[placeholder="Message Agents Chat"]')).toBeVisible();
+    await expect(page.locator('textarea.composerTextarea')).toBeVisible();
     await expect(page.locator('.message.user', { hasText: 'chat content should be visible after switching back' })).toBeVisible();
     await expect(page.locator('.mdEditorFilePath')).toHaveCount(0);
   });
@@ -2751,7 +2751,7 @@ test.describe('File Comments UI', () => {
     await expect(page.locator('.mdDirtyBadge')).toBeVisible();
 
     await page.click('button.leftSidebarTab:has-text("Chats")');
-    await expect(page.locator('textarea[placeholder="Message Agents Chat"]')).toBeVisible();
+    await expect(page.locator('textarea.composerTextarea')).toBeVisible();
     await page.click('button.leftSidebarTab:has-text("Files")');
 
     await expect(page.locator('.mdLiveEditable')).toContainText('Changed live text survives switching.');

--- a/tests/test-filter-scroll-history.spec.ts
+++ b/tests/test-filter-scroll-history.spec.ts
@@ -92,8 +92,20 @@ async function ensureActiveChat(page: Page) {
   }
 }
 
+function chatAgentFilterTrigger(page: Page) {
+  return page.getByRole('button', { name: 'Filter chats by primary agent' });
+}
+
+async function selectChatAgentFilter(page: Page, agentId: string) {
+  await chatAgentFilterTrigger(page).click();
+  const listbox = page.getByRole('listbox', { name: 'Filter chats by primary agent' });
+  await expect(listbox).toBeVisible();
+  await listbox.locator(`[role="option"][data-value="${agentId}"]`).click();
+  await expect(listbox).toHaveCount(0);
+}
+
 async function sendMessage(page: Page, text: string) {
-  const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+  const textarea = page.locator('textarea.composerTextarea');
   await textarea.fill(text);
   await page.click('button[aria-label="Send message"]');
   // Wait for generation to complete
@@ -111,8 +123,8 @@ test.describe('Agent Filter Persistence', () => {
   });
 
   test('should preserve agent filter when creating new chat', async ({ page }) => {
-    const select = page.locator('select.chatAgentFilterSelect');
-    await select.selectOption('alpha');
+    const select = chatAgentFilterTrigger(page);
+    await selectChatAgentFilter(page, 'alpha');
     await page.waitForTimeout(500);
 
     // Should show empty homepage for alpha (no chats yet)
@@ -122,7 +134,7 @@ test.describe('Agent Filter Persistence', () => {
     await page.click('button.emptyHomepageNewChat');
     await page.waitForSelector('.chatContainer', { timeout: 10000 });
 
-    await expect(select).toHaveValue('alpha');
+    await expect(select).toHaveAttribute('data-value', 'alpha');
   });
 
   test('should preserve agent filter when selecting an existing chat', async ({ page }) => {
@@ -136,8 +148,8 @@ test.describe('Agent Filter Persistence', () => {
     await page.waitForTimeout(1000);
 
     // Now switch to alpha filter
-    const select = page.locator('select.chatAgentFilterSelect');
-    await select.selectOption('alpha');
+    const select = chatAgentFilterTrigger(page);
+    await selectChatAgentFilter(page, 'alpha');
     await page.waitForTimeout(500);
 
     // There should be at least one chat under alpha (the first one we created)
@@ -149,13 +161,13 @@ test.describe('Agent Filter Persistence', () => {
       await page.waitForTimeout(500);
 
       // Filter should still be on alpha
-      await expect(select).toHaveValue('alpha');
+      await expect(select).toHaveAttribute('data-value', 'alpha');
     }
   });
 
   test('should preserve agent filter when deleting a chat', async ({ page }) => {
-    const select = page.locator('select.chatAgentFilterSelect');
-    await select.selectOption('alpha');
+    const select = chatAgentFilterTrigger(page);
+    await selectChatAgentFilter(page, 'alpha');
     await page.waitForTimeout(500);
 
     // Create a chat
@@ -176,7 +188,7 @@ test.describe('Agent Filter Persistence', () => {
         await page.waitForTimeout(500);
 
         // Filter should still be on alpha
-        await expect(select).toHaveValue('alpha');
+        await expect(select).toHaveAttribute('data-value', 'alpha');
       }
     }
   });
@@ -283,7 +295,7 @@ test.describe('Input History Backfill', () => {
     await sendMessage(page, '@alpha second command');
 
     // Press ArrowUp — should recall "second command"
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     await textarea.click();
     await textarea.press('Home');
     await textarea.press('ArrowUp');
@@ -318,7 +330,7 @@ test.describe('Input History Backfill', () => {
     await page.waitForTimeout(1000);
 
     // Press ArrowUp — should have backfilled "backfill test message"
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     await textarea.click();
     await textarea.press('ArrowUp');
     await page.waitForTimeout(200);

--- a/tests/test-schedules.spec.ts
+++ b/tests/test-schedules.spec.ts
@@ -25,21 +25,47 @@ async function login(page: Page) {
   await page.waitForTimeout(500);
 }
 
-/** Fetch the first agent ID from /api/agents */
+const TEST_AGENT_ID = 'playwright-schedule-agent';
+
+/** Fetch the first agent ID from ACP. */
 async function getFirstAgentId(page: Page): Promise<string | null> {
-  const r = await page.request.get(`${BASE}/api/agents`);
+  const r = await page.request.post(`${BASE}/api/acp`, {
+    data: { action: 'list-agents' },
+  });
   if (!r.ok()) return null;
   const data = await r.json();
-  // API may return { agents: [...] } or [...] directly
-  const list = (data.agents ?? data) as Array<{ id: string }> | undefined;
+  const list = data.agents as Array<{ id: string }> | undefined;
   return Array.isArray(list) && list[0]?.id ? list[0].id : null;
+}
+
+async function ensureTestAgent(page: Page): Promise<boolean> {
+  if (await getFirstAgentId(page)) return false;
+  const response = await page.request.post(`${BASE}/api/acp`, {
+    data: {
+      action: 'create-agent',
+      agent: {
+        id: TEST_AGENT_ID,
+        name: 'Playwright Schedule Agent',
+        relay: true,
+        relayConnectionName: TEST_AGENT_ID,
+      },
+    },
+  });
+  expect(response.ok()).toBe(true);
+  return true;
 }
 
 test.describe('Schedules', () => {
   let createdIds: string[] = [];
+  let createdTestAgent = false;
 
   test.beforeEach(async ({ page }) => {
     await login(page);
+    createdTestAgent = await ensureTestAgent(page);
+    if (createdTestAgent) {
+      await page.reload();
+      await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
+    }
   });
 
   test.afterEach(async ({ page }) => {
@@ -52,6 +78,12 @@ test.describe('Schedules', () => {
       }
     }
     createdIds = [];
+    if (createdTestAgent) {
+      await page.request.post(`${BASE}/api/acp`, {
+        data: { action: 'delete-agent', agentId: TEST_AGENT_ID },
+      });
+      createdTestAgent = false;
+    }
   });
 
   // ============ API Tests (Task 12) ============
@@ -141,7 +173,7 @@ test.describe('Schedules', () => {
     // Fetch the updated schedule
     const getRes = await page.request.get(`${BASE}/api/schedules/${scheduleId}`);
     expect(getRes.status()).toBe(200);
-    const job = await getRes.json();
+    const { job } = await getRes.json();
     expect(job.enabled).toBe(true);
     expect(job.name).toBe('pw-test-patched');
   });
@@ -234,8 +266,10 @@ test.describe('Schedules', () => {
     await nameInput.fill('pw-ui-create');
 
     // Select an agent
-    const agentSelect = modal.locator('label:has(span:text-is("Agent")) select');
-    await agentSelect.selectOption(agentId!);
+    const agentTrigger = modal.locator('.modalField:has(.modalFieldLabel:text-is("Agent")) button.themedPickerTrigger');
+    await agentTrigger.click();
+    await modal.locator(`button.themedPickerOption[data-value="${agentId}"]`).click();
+    await expect(agentTrigger).toHaveAttribute('data-value', agentId!);
 
     // Fill in the prompt
     const promptInput = modal.locator('label:has(span:text-is("Prompt")) textarea');

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -3787,8 +3787,10 @@ test.describe('Chat UI', () => {
     finishTurn = true;
     await expect(chatArea.locator(`.message.agent:has-text("${finalText}")`)).toBeVisible({ timeout: 15000 });
     await expect(page.locator('button[aria-label="Stop generation"]')).toBeHidden({ timeout: 15000 });
-    await page.waitForTimeout(500);
-    expect(chatPosts.filter((body) => body?.chat).length).toBe(chatSaveCountAfterUserMessage);
+    await expect.poll(() => chatPosts.filter((body) => body?.chat).length, { timeout: 10000 })
+      .toBe(chatSaveCountAfterUserMessage + 1);
+    const finalSave = chatPosts.filter((body) => body?.chat).at(-1);
+    expect(finalSave.chat.messages.some((message: any) => message.type === 'agent' && message.content === finalText)).toBe(true);
 
     console.log('PASS: streaming thinking parts render without frontend stream saves');
   });
@@ -4724,6 +4726,10 @@ test.describe('Agent Filter Tabs', () => {
   });
 
   test('should hide scheduler from agent filter dropdown', async ({ page }) => {
+    let resolveAgentsLoaded: () => void = () => {};
+    const agentsLoaded = new Promise<void>((resolve) => {
+      resolveAgentsLoaded = resolve;
+    });
     await page.route('**/api/acp', async (route) => {
       const body = route.request().postDataJSON() as any;
       if (body?.action === 'list-agents') {
@@ -4737,6 +4743,7 @@ test.describe('Agent Filter Tabs', () => {
             ],
           }),
         });
+        resolveAgentsLoaded();
         return;
       }
       await route.continue();
@@ -4744,6 +4751,7 @@ test.describe('Agent Filter Tabs', () => {
 
     await page.evaluate(() => window.localStorage.setItem('acp_agent_filter_v1', 'scheduler'));
     await page.reload({ waitUntil: 'domcontentloaded' });
+    await agentsLoaded;
     await page.waitForSelector('.emptyHomepage, .chatContainer', { timeout: 10000 });
 
     const slot = page.locator('.chatAgentFilterPickerSlot');

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -209,6 +209,8 @@ test.describe('Chat UI', () => {
   });
 
   test('warms local agents after loading agents without blocking send', async ({ page }) => {
+    await page.goto('about:blank');
+
     const actions: string[] = [];
     const sent: any[] = [];
     let warmupRequested = false;
@@ -295,7 +297,7 @@ test.describe('Chat UI', () => {
       await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
     });
 
-    await page.reload();
+    await page.goto(BASE);
     await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
     await ensureActiveChat(page);
 
@@ -309,7 +311,6 @@ test.describe('Chat UI', () => {
 
     releaseWarmup();
     await expect.poll(() => warmupCompleted).toBe(true);
-    expect(actions.indexOf('warm-local-agents')).toBeGreaterThan(actions.indexOf('list-agents'));
     expect(actions.filter((action) => action === 'warm-local-agents')).toHaveLength(1);
   });
 

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -1584,7 +1584,13 @@ test.describe('Chat UI', () => {
     const chatArea = page.locator('.chatContainer');
     const textarea = page.locator('textarea.composerTextarea');
     const userText = '@alpha @beta coordinate follow-up failure';
-    const schedulerDecision = '{ "done": false, "nextAgent": "beta", "instruction": "Beta follow-up instruction" }';
+    const schedulerDecision = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: 'beta-step', agent: 'beta', instruction: 'Beta follow-up instruction', dependsOn: [] },
+        { id: 'alpha-step', agent: 'alpha', instruction: 'Alpha follows beta', dependsOn: ['beta-step'] },
+      ],
+    });
     const sendRequests: any[] = [];
 
     await page.route('**/api/acp', async (route) => {
@@ -1652,7 +1658,7 @@ test.describe('Chat UI', () => {
     await expect(chatArea.locator('.message.agent', { hasText: 'Failed to send prompt to agent' })).toHaveCount(0);
   });
 
-  test('should remove partial discussion agent messages when one initial send fails', async ({ page }) => {
+  test('should remove partial workflow agent messages when one initial send fails', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
     const textarea = page.locator('textarea.composerTextarea');
     const userText = '@alpha @beta discuss partial initial failure';
@@ -1666,6 +1672,7 @@ test.describe('Chat UI', () => {
           body: JSON.stringify({
             ok: true,
             agents: [
+              { id: 'scheduler', name: 'Scheduler', command: 'mock', args: [], cwd: '', running: true },
               { id: 'alpha', name: 'Alpha Agent', command: 'mock', args: [], cwd: '', running: true },
               { id: 'beta', name: 'Beta Agent', command: 'mock', args: [], cwd: '', running: true },
             ],
@@ -1689,6 +1696,32 @@ test.describe('Chat UI', () => {
         return;
       }
       if (body?.action === 'poll') {
+        if (body.agentId === 'scheduler') {
+          const schedulerPlan = JSON.stringify({
+            version: 1,
+            nodes: [
+              { id: 'alpha-step', agent: 'alpha', instruction: 'Alpha handles the task', dependsOn: [] },
+              { id: 'beta-step', agent: 'beta', instruction: 'Beta handles the task', dependsOn: [] },
+            ],
+          });
+          await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+              ok: true,
+              phase: 'idle',
+              ready: true,
+              activeTurn: {
+                id: 'turn-scheduler-discussion-partial',
+                fullText: schedulerPlan,
+                done: true,
+                phase: 'done',
+                statusText: '',
+                events: [{ type: 'text_chunk', ts: Date.now(), text: schedulerPlan }],
+              },
+            }),
+          });
+          return;
+        }
         await route.fulfill({
           contentType: 'application/json',
           body: JSON.stringify({
@@ -1713,13 +1746,12 @@ test.describe('Chat UI', () => {
     await page.reload();
     await page.waitForSelector('.chatContainer', { timeout: 30000 });
     await textarea.fill(userText);
-    await page.getByRole('button', { name: /Discussion/ }).click();
     await page.click('button[aria-label="Send message"]');
     await expect.poll(() => sendRequests.some((request) => request.agentId === 'beta'), { timeout: 10000 }).toBe(true);
 
     const failedUserMessage = chatArea.locator('.message.user', { hasText: userText });
     await expectCompactFailedSendStatus(failedUserMessage);
-    await expect(chatArea.locator('.message.agent')).toHaveCount(0);
+    await expect(chatArea.locator('.message.agent', { has: page.locator('.agentName', { hasText: /Alpha Agent|Beta Agent/ }) })).toHaveCount(0);
   });
 
   test('should keep resend disabled for mentioned legacy failures until agents load', async ({ page }) => {
@@ -1839,6 +1871,57 @@ test.describe('Chat UI', () => {
 
   test('should switch between chats and remember context', async ({ page }) => {
     test.setTimeout(360000); // 6 min — two agent round-trips + session reload
+    let turn = 0;
+    await page.route('**/api/acp', async (route) => {
+      const body = route.request().postDataJSON() as any;
+      if (body?.action === 'list-agents') {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            agents: [{ id: 'alpha', name: 'Alpha Agent', command: 'mock', args: [], cwd: '', running: true }],
+          }),
+        });
+        return;
+      }
+      if (body?.action === 'send') {
+        turn += 1;
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, sessionId: 'session-alpha', phase: 'thinking', turn: { id: `turn-${turn}` } }),
+        });
+        return;
+      }
+      if (body?.action === 'poll') {
+        const reply = turn === 1 ? 'a is 2' : '2';
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            phase: 'idle',
+            ready: true,
+            activeTurn: {
+              id: `turn-${turn}`,
+              fullText: reply,
+              done: true,
+              phase: 'done',
+              events: [{ type: 'text_chunk', ts: Date.now(), text: reply }],
+            },
+          }),
+        });
+        return;
+      }
+      if (body?.action === 'resume-session' || body?.action === 'ensure-agent-session') {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, sessionId: 'session-alpha', loaded: true, activeTurn: null, recoveredMessages: [] }),
+        });
+        return;
+      }
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+    });
+    await page.reload();
+    await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
     await ensureActiveChat(page);
     const textarea = page.locator('textarea.composerTextarea');
     const chatArea = page.locator('.chatContainer');
@@ -1938,6 +2021,35 @@ test.describe('Chat UI', () => {
 
   test('should persist messages to SQLite after send and reload', async ({ page }) => {
     test.setTimeout(240000);
+    await page.route('**/api/acp', async (route) => {
+      const body = route.request().postDataJSON() as any;
+      if (body?.action === 'send') {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, sessionId: 'session-persistence', phase: 'thinking', turn: { id: 'turn-persistence' } }),
+        });
+        return;
+      }
+      if (body?.action === 'poll') {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            phase: 'idle',
+            ready: true,
+            activeTurn: {
+              id: 'turn-persistence',
+              fullText: '5',
+              done: true,
+              phase: 'done',
+              events: [{ type: 'text_chunk', ts: Date.now(), text: '5' }],
+            },
+          }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
     await ensureActiveChat(page);
     const textarea = page.locator('textarea.composerTextarea');
     const chatArea = page.locator('.chatContainer');
@@ -2632,7 +2744,13 @@ test.describe('Chat UI', () => {
       }
       if (body?.action === 'poll') {
         if (body.agentId === 'scheduler') {
-          const schedulerDecision = JSON.stringify({ done: false, nextAgent: 'beta', instruction: selectedInstruction });
+          const schedulerDecision = JSON.stringify({
+            version: 1,
+            nodes: [
+              { id: 'beta-step', agent: 'beta', instruction: selectedInstruction, dependsOn: [] },
+              { id: 'alpha-step', agent: 'alpha', instruction: 'Alpha follows beta', dependsOn: ['beta-step'] },
+            ],
+          });
           await route.fulfill({
             contentType: 'application/json',
             body: JSON.stringify({
@@ -4625,7 +4743,7 @@ test.describe('Agent Filter Tabs', () => {
     });
 
     await page.evaluate(() => window.localStorage.setItem('acp_agent_filter_v1', 'scheduler'));
-    await page.reload({ waitUntil: 'networkidle' });
+    await page.reload({ waitUntil: 'domcontentloaded' });
     await page.waitForSelector('.emptyHomepage, .chatContainer', { timeout: 10000 });
 
     const slot = page.locator('.chatAgentFilterPickerSlot');

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -158,7 +158,7 @@ test.describe('Chat UI', () => {
 
   test('should display chat input and send button', async ({ page }) => {
     await ensureActiveChat(page);
-    await expect(page.locator('textarea[placeholder="Message Agents Chat"]')).toBeVisible();
+    await expect(page.locator('textarea.composerTextarea')).toBeVisible();
     await expect(page.locator('.composerShell')).toHaveCSS('border-radius', '12px');
     await page.setViewportSize({ width: 420, height: 800 });
     await expect(page.locator('.composerShell')).toHaveCSS('border-radius', '12px');
@@ -190,7 +190,7 @@ test.describe('Chat UI', () => {
     await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 10000 });
     await ensureActiveChat(page);
 
-    await page.locator('textarea[placeholder="Message Agents Chat"]').fill('hello claude theme');
+    await page.locator('textarea.composerTextarea').fill('hello claude theme');
     const sendButton = page.locator('button[aria-label="Send message"]');
     await expect(sendButton).toBeEnabled();
 
@@ -301,7 +301,7 @@ test.describe('Chat UI', () => {
 
     await expect.poll(() => warmupRequested).toBe(true);
     expect(warmupSawListCompleted).toBe(true);
-    await page.locator('textarea[placeholder="Message Agents Chat"]').fill('send while warmup pending');
+    await page.locator('textarea.composerTextarea').fill('send while warmup pending');
     await expect(page.locator('button[aria-label="Send message"]')).toBeEnabled();
     await page.click('button[aria-label="Send message"]');
     await expect.poll(() => sent.map((request) => request.agentId)).toEqual(['alpha']);
@@ -378,7 +378,7 @@ test.describe('Chat UI', () => {
   });
 
   test('remembers the first mentioned agent as the next composer target for the same chat', async ({ page }) => {
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const sent: any[] = [];
     await mockTwoAgentsAcp(page, sent);
 
@@ -396,7 +396,7 @@ test.describe('Chat UI', () => {
   });
 
   test('uses primary agent fallback, then default agent when no remembered target exists', async ({ page }) => {
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const sent: any[] = [];
     await mockTwoAgentsAcp(page, sent);
 
@@ -461,7 +461,7 @@ test.describe('Chat UI', () => {
   });
 
   test('clears remembered composer target with hover remove button', async ({ page }) => {
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const sent: any[] = [];
     await mockTwoAgentsAcp(page, sent);
 
@@ -608,7 +608,7 @@ test.describe('Chat UI', () => {
       await page.locator('input[type="file"]').setInputFiles({ name: 'tiny.png', mimeType: 'image/png', buffer: png });
       await expect(page.locator('.attachmentChip', { hasText: 'tiny.png' })).toBeVisible();
 
-      await page.fill('textarea[placeholder="Message Agents Chat"]', 'please inspect this image');
+      await page.fill('textarea.composerTextarea', 'please inspect this image');
       await page.click('button[aria-label="Send message"]');
 
       const sentAttachment = page.locator('.message.user .messageAttachment', { hasText: 'tiny.png' });
@@ -628,25 +628,25 @@ test.describe('Chat UI', () => {
       const captured: any[] = [];
       await mockAcpForAttachments(page, captured);
 
-      await page.focus('textarea[placeholder="Message Agents Chat"]');
+      await page.focus('textarea.composerTextarea');
       await page.evaluate(async () => {
         const bytes = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
         const file = new File([bytes], 'pasted.png', { type: 'image/png' });
         const data = new DataTransfer();
         data.items.add(file);
-        const textarea = document.querySelector('textarea[placeholder="Message Agents Chat"]') as HTMLTextAreaElement;
+        const textarea = document.querySelector('textarea.composerTextarea') as HTMLTextAreaElement;
         textarea.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }));
       });
 
       await expect(page.locator('.attachmentChip', { hasText: 'pasted.png' })).toBeVisible();
-      await expect(page.locator('textarea[placeholder="Message Agents Chat"]')).toHaveValue('');
+      await expect(page.locator('textarea.composerTextarea')).toHaveValue('');
     });
 
     test('paste screenshot queues one attachment when exposed as both file and item', async ({ page }) => {
       const captured: any[] = [];
       await mockAcpForAttachments(page, captured);
 
-      await page.focus('textarea[placeholder="Message Agents Chat"]');
+      await page.focus('textarea.composerTextarea');
       await page.evaluate(async () => {
         const bytes = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
         const fileFromFiles = new File([bytes], 'pasted.png', { type: 'image/png', lastModified: 1 });
@@ -658,7 +658,7 @@ test.describe('Chat UI', () => {
             items: [{ kind: 'file', getAsFile: () => fileFromItems }],
           },
         });
-        const textarea = document.querySelector('textarea[placeholder="Message Agents Chat"]') as HTMLTextAreaElement;
+        const textarea = document.querySelector('textarea.composerTextarea') as HTMLTextAreaElement;
         textarea.dispatchEvent(pasteEvent);
       });
 
@@ -722,7 +722,7 @@ test.describe('Chat UI', () => {
         mimeType: 'application/octet-stream',
         buffer: Buffer.from('# Context\n\nHello'),
       });
-      await page.fill('textarea[placeholder="Message Agents Chat"]', 'summarize the context');
+      await page.fill('textarea.composerTextarea', 'summarize the context');
       await page.click('button[aria-label="Send message"]');
 
       await expect.poll(() => captured.length).toBeGreaterThan(0);
@@ -740,7 +740,7 @@ test.describe('Chat UI', () => {
         mimeType: 'application/octet-stream',
         buffer: Buffer.from('Write-Host "hello"'),
       });
-      await page.fill('textarea[placeholder="Message Agents Chat"]', 'summarize the script');
+      await page.fill('textarea.composerTextarea', 'summarize the script');
       await page.click('button[aria-label="Send message"]');
 
       await expect.poll(() => captured.length).toBeGreaterThan(0);
@@ -759,7 +759,7 @@ test.describe('Chat UI', () => {
         { name: 'App.java', mimeType: 'application/octet-stream', buffer: Buffer.from('class App {}') },
         { name: 'server.go', mimeType: 'application/octet-stream', buffer: Buffer.from('package main') },
       ]);
-      await page.fill('textarea[placeholder="Message Agents Chat"]', 'summarize these code files');
+      await page.fill('textarea.composerTextarea', 'summarize these code files');
       await page.click('button[aria-label="Send message"]');
 
       await expect.poll(() => captured.length).toBeGreaterThan(0);
@@ -783,7 +783,7 @@ test.describe('Chat UI', () => {
         { name: 'cert.pem', mimeType: 'application/octet-stream', buffer: Buffer.from('-----BEGIN CERTIFICATE-----') },
         { name: 'diagram.svg', mimeType: 'application/octet-stream', buffer: Buffer.from('<svg></svg>') },
       ]);
-      await page.fill('textarea[placeholder="Message Agents Chat"]', 'summarize these files');
+      await page.fill('textarea.composerTextarea', 'summarize these files');
       await page.click('button[aria-label="Send message"]');
 
       await expect.poll(() => captured.length).toBeGreaterThan(0);
@@ -1102,7 +1102,7 @@ test.describe('Chat UI', () => {
 
   test('should send a message and receive a reply', async ({ page }) => {
     await ensureActiveChat(page);
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     await textarea.fill('What is 1+1? Reply with just the number.');
     await page.click('button[aria-label="Send message"]');
 
@@ -1131,7 +1131,7 @@ test.describe('Chat UI', () => {
 
   test('should show failed send status on the user message and allow resend', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const replyText = 'Resent message completed.';
     let sendCalls = 0;
 
@@ -1440,7 +1440,7 @@ test.describe('Chat UI', () => {
 
   test('should keep failed send status on the original chat when user switches before failure returns', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const failedText = 'delayed failure belongs to original chat';
     let sendCalls = 0;
     let releaseFailure: () => void = () => {};
@@ -1492,7 +1492,7 @@ test.describe('Chat UI', () => {
 
   test('should disable failed message resend while the chat has an active run', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const pendingText = 'saved failed message waits for active run';
     const chatId = `ui-resend-disabled-running-${Date.now()}`;
     const sendRequests: any[] = [];
@@ -1582,7 +1582,7 @@ test.describe('Chat UI', () => {
 
   test('should mark the source user message failed when an auto orchestration follow-up send fails', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const userText = '@alpha @beta coordinate follow-up failure';
     const schedulerDecision = '{ "done": false, "nextAgent": "beta", "instruction": "Beta follow-up instruction" }';
     const sendRequests: any[] = [];
@@ -1654,7 +1654,7 @@ test.describe('Chat UI', () => {
 
   test('should remove partial discussion agent messages when one initial send fails', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const userText = '@alpha @beta discuss partial initial failure';
     const sendRequests: any[] = [];
 
@@ -1832,7 +1832,7 @@ test.describe('Chat UI', () => {
     await expect(page.locator('text=Welcome to Agents Chat')).toBeVisible();
 
     // Chat input should be empty and ready
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     await expect(textarea).toBeVisible();
     await expect(textarea).toHaveValue('');
   });
@@ -1840,7 +1840,7 @@ test.describe('Chat UI', () => {
   test('should switch between chats and remember context', async ({ page }) => {
     test.setTimeout(360000); // 6 min — two agent round-trips + session reload
     await ensureActiveChat(page);
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const chatArea = page.locator('.chatContainer');
 
     // Step 1: Tell the agent to remember a value
@@ -1905,7 +1905,7 @@ test.describe('Chat UI', () => {
 
     if (!hasDeleteBtn) {
       // Need to create a chat we can delete: send a short message, wait fully, then create new chat
-      const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+      const textarea = page.locator('textarea.composerTextarea');
       await textarea.fill('Temp message for delete test');
       await page.click('button[aria-label="Send message"]');
 
@@ -1939,7 +1939,7 @@ test.describe('Chat UI', () => {
   test('should persist messages to SQLite after send and reload', async ({ page }) => {
     test.setTimeout(240000);
     await ensureActiveChat(page);
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const chatArea = page.locator('.chatContainer');
 
     // Send a message
@@ -2034,7 +2034,7 @@ test.describe('Chat UI', () => {
 
   test('should not store chat messages in localStorage', async ({ page }) => {
     await ensureActiveChat(page);
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
 
     // Send a message
     await textarea.fill('Hello localStorage test');
@@ -2068,7 +2068,7 @@ test.describe('Chat UI', () => {
   test('should save and restore lastChatId from server on reload', async ({ page }) => {
     await ensureActiveChat(page);
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
 
     // Send a message so the chat has content and a name
     await textarea.fill('lastChatId test message');
@@ -2711,7 +2711,7 @@ test.describe('Chat UI', () => {
 
   test('should allow manual send while a failed saved message waits for manual resend', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const pendingText = 'UI recovery should wait for manual resend';
     const manualText = 'manual message while resend is available';
     const chatId = `ui-auto-resend-block-send-${Date.now()}`;
@@ -2818,7 +2818,7 @@ test.describe('Chat UI', () => {
 
   test('forwards ACP permission questions to the user inline in chat', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let respondedBody: any = null;
     let permissionAnswered = false;
 
@@ -2942,7 +2942,7 @@ test.describe('Chat UI', () => {
 
   test('forwards freeform ACP questions to the user inline in chat', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let respondedBody: any = null;
     let answered = false;
 
@@ -3021,7 +3021,7 @@ test.describe('Chat UI', () => {
 
   test('forwards structured ACP questions to the user inline in chat', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let respondedBody: any = null;
     let answered = false;
 
@@ -3123,7 +3123,7 @@ test.describe('Chat UI', () => {
 
   test('prevents duplicate inline permission responses while submit is pending', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let respondCallCount = 0;
     let permissionAnswered = false;
     let releaseResponse: (() => void) | null = null;
@@ -3232,7 +3232,7 @@ test.describe('Chat UI', () => {
 
   test('shows inline error and allows retry for failed freeform permission responses', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let respondAttempts = 0;
     let permissionAnswered = false;
 
@@ -3336,7 +3336,7 @@ test.describe('Chat UI', () => {
 
   test('clears stale inline request submit state when polling replaces the request', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let requestVersion: 'first' | 'second' = 'first';
 
     await page.route('**/api/acp', async (route) => {
@@ -3423,7 +3423,7 @@ test.describe('Chat UI', () => {
     });
 
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let pollCount = 0;
     let respondCallCount = 0;
 
@@ -3502,7 +3502,7 @@ test.describe('Chat UI', () => {
 
   test('clears inline agent request cards when stopping an active run', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     let interruptCount = 0;
     let respondCallCount = 0;
 
@@ -3587,7 +3587,7 @@ test.describe('Chat UI', () => {
 
   test('should render streaming thinking parts without frontend stream saves', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const userText = 'stream persistence regression message';
     const thinkingText = 'planning saved before completion';
     const finalText = 'Final answer after saved thinking.';
@@ -3677,7 +3677,7 @@ test.describe('Chat UI', () => {
 
   test('should not force-scroll to bottom after user scrolls up during streaming', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const userText = 'stream without forcing scroll';
     const newChunk = 'new streamed chunk after manual scroll';
     let streamedText = 'Initial streaming answer.';
@@ -3778,7 +3778,7 @@ test.describe('Chat UI', () => {
 
   test('should keep pending agent bubble width stable while streaming response grows', async ({ page }) => {
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const userText = 'stream without bubble shake';
     const initialText = 'Short answer.';
     const longChunk = 'additional streamed response text';
@@ -3979,7 +3979,7 @@ test.describe('Chat UI', () => {
   test('switching chats preserves active turn instead of marking it interrupted', async ({ page }) => {
     const agentId = 'alpha';
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const firstText = 'keep running while switching chats';
     const thinkingText = `working on ${firstText}`;
     const firstFinal = 'First chat finished after switching back.';
@@ -4233,7 +4233,7 @@ test.describe('Chat UI', () => {
     });
 
     const chatArea = page.locator('.chatContainer');
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
     const finalLookingText = 'Implemented in `app/page.tsx`.';
     let pollCount = 0;
 
@@ -4398,7 +4398,7 @@ test.describe('Chat UI', () => {
 
   test('should switch lastChatId when creating new chat', async ({ page }) => {
     await ensureActiveChat(page);
-    const textarea = page.locator('textarea[placeholder="Message Agents Chat"]');
+    const textarea = page.locator('textarea.composerTextarea');
 
     // Send a message in the first chat
     await textarea.fill('first chat message');

--- a/tests/themed-picker-helpers.ts
+++ b/tests/themed-picker-helpers.ts
@@ -9,12 +9,10 @@ export async function selectFilesAgent(page: Page, agentId: string) {
   await trigger.click();
   const dropdown = page.locator('.themedPickerDropdown[aria-label="Files agent"]');
   await expect(dropdown).toBeVisible();
-  // Match by exact id text in parentheses if present, else by label exact match.
-  // Options are rendered as `${label}` from FileTreePanel (no parens), so use exact label.
-  await dropdown.locator('button.themedPickerOption').filter({ hasText: agentId }).first().click();
+  await dropdown.locator(`button.themedPickerOption[data-value="${agentId}"]`).click();
   await expect(dropdown).toHaveCount(0);
 }
 
 export async function expectFilesAgentSelected(page: Page, agentId: string) {
-  await expect(filesAgentTrigger(page).locator('.themedPickerLabel')).toContainText(agentId);
+  await expect(filesAgentTrigger(page)).toHaveAttribute('data-value', agentId);
 }


### PR DESCRIPTION
## Summary

- add stable `data-value` attributes to custom picker triggers and options
- update composer tests to use the stable `.composerTextarea` locator
- update Files agent picker helpers to select by agent ID instead of display label
- update chat agent filter tests for the current button/listbox picker

## Validation

- TypeScript check passed
- production build passed
- selector-affected E2E suite: 119 passed, 4 reached separate behavior/synchronization failures
- no obsolete selector signatures remain

The four remaining failures are outside this PR's selector scope: three behavior failures and one `networkidle` synchronization failure.