### PR TITLE
Expand Playwright feature coverage

### DIFF
--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -389,11 +389,12 @@
   backdrop-filter: blur(18px);
   box-shadow: var(--shadow);
   max-height: 80px;
-  overflow: hidden;
+  overflow: visible;
   transition: max-height 180ms ease, padding 180ms ease, opacity 160ms ease, border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 .chatPageRoot .header.headerHidden {
   max-height: 0;
+  overflow: hidden;
   padding-top: 0;
   padding-bottom: 0;
   border-bottom-color: transparent;

--- a/tests/agent-node-management.spec.ts
+++ b/tests/agent-node-management.spec.ts
@@ -1,0 +1,414 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+type Agent = {
+  id: string;
+  name: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  yolo?: boolean;
+  env?: Record<string, string>;
+  relay?: boolean;
+  relayConnectionName?: string;
+  owner?: string;
+  canModify: boolean;
+  canTalk: boolean;
+  public?: boolean;
+  models: unknown[];
+};
+
+type Node = {
+  name: string;
+  label: string;
+  online: boolean;
+  checkedAt: number;
+  manual: boolean;
+  owner: string;
+  canModify: boolean;
+};
+
+type AccessEntry = { email: string; grantedBy: string; createdAt: string };
+
+async function installIsolatedBackend(page: Page) {
+  const agents = new Map<string, Agent>([
+    ['locked-agent', {
+      id: 'locked-agent',
+      name: 'Locked Agent',
+      command: 'locked-command',
+      args: ['--acp'],
+      cwd: '/locked',
+      yolo: false,
+      env: {},
+      owner: 'other@example.com',
+      canModify: false,
+      canTalk: false,
+      public: false,
+      models: [],
+    }],
+  ]);
+  const nodes = new Map<string, Node>([
+    ['remote-owned', {
+      name: 'remote-owned',
+      label: 'Owned Remote Node',
+      online: true,
+      checkedAt: 100,
+      manual: true,
+      owner: 'admin@local',
+      canModify: true,
+    }],
+    ['locked-node', {
+      name: 'locked-node',
+      label: 'Locked Node',
+      online: false,
+      checkedAt: 100,
+      manual: true,
+      owner: 'other@example.com',
+      canModify: false,
+    }],
+  ]);
+  const access = new Map<string, AccessEntry[]>();
+  const acpRequests: Record<string, any>[] = [];
+  const nodeRequests: Record<string, any>[] = [];
+  const chat = {
+    id: 'management-chat',
+    name: 'Management coverage',
+    ts: 1_000,
+    messages: [{ id: 'welcome-user', type: 'user', content: 'Manage test resources.', ts: 1_001 }],
+    agentSessions: {},
+  };
+
+  await page.route('**/api/chats**', async (route) => {
+    const request = route.request();
+    const id = new URL(request.url()).searchParams.get('id');
+    if (request.method() === 'GET') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(id
+          ? { ok: true, chat }
+          : { ok: true, chats: [{ id: chat.id, name: chat.name, ts: chat.ts }], lastChatId: chat.id }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as Record<string, any>;
+    acpRequests.push(body);
+    const agentId = body.agentId as string | undefined;
+
+    if (body.action === 'list-agents') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, agents: [...agents.values()] }),
+      });
+      return;
+    }
+    if (body.action === 'create-agent') {
+      const input = body.agent;
+      agents.set(input.id, {
+        command: input.relay ? undefined : input.command,
+        args: input.relay ? undefined : input.args,
+        cwd: input.cwd,
+        env: input.env || {},
+        yolo: input.yolo,
+        public: false,
+        relay: !!input.relay,
+        relayConnectionName: input.relayConnectionName,
+        owner: 'admin@local',
+        canModify: true,
+        canTalk: true,
+        models: [],
+        id: input.id,
+        name: input.name,
+      });
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, agent: agents.get(input.id) }) });
+      return;
+    }
+    if (body.action === 'get-agent-config') {
+      const agent = agentId ? agents.get(agentId) : undefined;
+      await route.fulfill({
+        status: agent ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(agent ? { ok: true, agent } : { ok: false, error: 'agent_not_found' }),
+      });
+      return;
+    }
+    if (body.action === 'update-agent-config' && agentId) {
+      const current = agents.get(agentId)!;
+      agents.set(agentId, { ...current, ...body.updates });
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, agent: agents.get(agentId), restarted: false }),
+      });
+      return;
+    }
+    if (body.action === 'delete-agent' && agentId) {
+      agents.delete(agentId);
+      access.delete(agentId);
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    if (body.action === 'list-agent-access' && agentId) {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, access: access.get(agentId) || [] }),
+      });
+      return;
+    }
+    if (body.action === 'add-agent-access' && agentId) {
+      const current = access.get(agentId) || [];
+      access.set(agentId, [
+        ...current.filter((entry) => entry.email !== body.email),
+        { email: body.email, grantedBy: 'admin@local', createdAt: '2026-07-16T00:00:00.000Z' },
+      ]);
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    if (body.action === 'remove-agent-access' && agentId) {
+      access.set(agentId, (access.get(agentId) || []).filter((entry) => entry.email !== body.email));
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/nodes', async (route) => {
+    const body = route.request().postDataJSON() as Record<string, any>;
+    nodeRequests.push(body);
+    if (body.action === 'list-nodes') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, nodes: [...nodes.values()] }),
+      });
+      return;
+    }
+    if (body.action === 'add-node') {
+      nodes.set(body.name, {
+        name: body.name,
+        label: body.label || body.name,
+        online: false,
+        checkedAt: 200,
+        manual: true,
+        owner: 'admin@local',
+        canModify: true,
+      });
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    if (body.action === 'check-node') {
+      const node = nodes.get(body.name)!;
+      node.online = true;
+      node.checkedAt = 300;
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, name: body.name, online: true, checkedAt: 300 }),
+      });
+      return;
+    }
+    if (body.action === 'update-node') {
+      const node = nodes.get(body.name)!;
+      node.label = body.label;
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    if (body.action === 'remove-node') {
+      nodes.delete(body.name);
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    await route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ ok: false, error: 'unknown action' }) });
+  });
+
+  return { agents, nodes, access, acpRequests, nodeRequests };
+}
+
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await expect(page.locator('.message.user')).toBeVisible({ timeout: 30_000 });
+}
+
+async function openAgents(page: Page) {
+  await page.locator('button[title="Agents"]').click();
+  await expect(page.locator('.agentsSidebar').filter({ hasText: 'Agents' })).toBeVisible();
+}
+
+function settingsField(modal: Locator, name: string) {
+  return modal.locator('label').filter({ hasText: new RegExp(`^${name}`) }).locator('input').first();
+}
+
+test.describe('agent and node management', () => {
+  test('creates, edits permissions and environment, then deletes a local server agent', async ({ page }) => {
+    const backend = await installIsolatedBackend(page);
+    await login(page);
+    await openAgents(page);
+
+    const agentsPanel = page.locator('.agentsSidebar').filter({ hasText: 'Agents' });
+    const locked = agentsPanel.locator('.agentListItem', { hasText: 'Locked Agent' });
+    await expect(locked.locator('.agentListName')).toContainText('🔒');
+    await expect(locked).toHaveAttribute('title', 'Locked Agent');
+    await locked.click();
+    await expect(page.locator('.agentSettingsModal')).toHaveCount(0);
+
+    await agentsPanel.locator('button[title="Add agent"]').click();
+    await page.getByRole('button', { name: /Add Agent in Server/ }).click();
+    const addModal = page.locator('.agentSettingsModal', { hasText: 'Add New Agent' });
+    await addModal.getByPlaceholder('unique-agent-id').fill('managed-local');
+    await addModal.getByPlaceholder('My Agent').fill('Managed Local');
+    await addModal.getByPlaceholder('copilot.exe').fill('mock-copilot');
+    await addModal.getByPlaceholder('--acp').fill('--acp --safe');
+    await addModal.getByPlaceholder('C:\\path\\to\\project').fill('/workspace/original');
+    await addModal.locator('textarea').fill('TOKEN=initial\nIGNORED\nMODE=test');
+    await addModal.getByRole('checkbox', { name: /YOLO mode/ }).uncheck();
+    await addModal.getByRole('button', { name: 'Create Agent' }).click();
+
+    await expect(agentsPanel.locator('.agentListItem', { hasText: 'Managed Local' })).toBeVisible();
+    expect(backend.agents.get('managed-local')).toMatchObject({
+      command: 'mock-copilot',
+      args: ['--acp', '--safe'],
+      cwd: '/workspace/original',
+      yolo: false,
+      env: { TOKEN: 'initial', MODE: 'test' },
+    });
+
+    await agentsPanel.locator('.agentListItem', { hasText: 'Managed Local' }).click();
+    const settings = page.locator('.agentSettingsModal', { hasText: 'Managed Local' });
+    await expect(settings).toBeVisible();
+    await expect(settingsField(settings, 'Agent ID')).toBeDisabled();
+    await settingsField(settings, 'Name').fill('Managed Local Updated');
+    await settingsField(settings, 'Command').fill('mock-copilot-v2');
+    await settingsField(settings, 'Arguments').fill('--acp --verbose');
+    await settingsField(settings, 'Working Directory').fill('/workspace/updated');
+    await settings.getByRole('checkbox', { name: /YOLO mode/ }).check();
+    await settings.locator('textarea').fill('TOKEN=updated\nEXTRA=value=with-equals');
+
+    const publicToggle = settings.getByRole('checkbox', { name: /Public/ });
+    await publicToggle.check();
+    await expect(settings.getByPlaceholder('user@email.com')).toHaveCount(0);
+    await publicToggle.uncheck();
+    await settings.getByPlaceholder('user@email.com').fill('reader@example.com');
+    await settings.getByRole('button', { name: 'Grant' }).click();
+    const accessEmail = settings.getByText('reader@example.com', { exact: true });
+    await expect(accessEmail).toBeVisible();
+    await accessEmail.locator('..').getByRole('button').click();
+    await expect(settings.getByText('reader@example.com', { exact: true })).toHaveCount(0);
+
+    await settings.getByRole('button', { name: 'Save' }).click();
+    await expect(agentsPanel.locator('.agentListItem', { hasText: 'Managed Local Updated' })).toBeVisible();
+    expect(backend.agents.get('managed-local')).toMatchObject({
+      name: 'Managed Local Updated',
+      command: 'mock-copilot-v2',
+      args: ['--acp', '--verbose'],
+      cwd: '/workspace/updated',
+      yolo: true,
+      public: false,
+      env: { TOKEN: 'updated', EXTRA: 'value=with-equals' },
+    });
+
+    await agentsPanel.locator('.agentListItem', { hasText: 'Managed Local Updated' }).click();
+    await expect(settingsField(page.locator('.agentSettingsModal'), 'Name')).toHaveValue('Managed Local Updated');
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.locator('.agentSettingsModal').getByRole('button', { name: 'Delete' }).click();
+    await expect(agentsPanel.locator('.agentListItem', { hasText: 'Managed Local Updated' })).toHaveCount(0);
+    expect(backend.agents.has('managed-local')).toBe(false);
+  });
+
+  test('creates a remote agent from the Agents panel with the selected node', async ({ page }) => {
+    const backend = await installIsolatedBackend(page);
+    await login(page);
+    await openAgents(page);
+
+    const agentsPanel = page.locator('.agentsSidebar').filter({ hasText: 'Agents' });
+    await agentsPanel.locator('button[title="Add agent"]').click();
+    await page.getByRole('button', { name: /Add Agent from Remote Node/ }).click();
+    const modal = page.locator('.agentSettingsModal', { hasText: 'Add Agent from Remote Node' });
+    await modal.getByPlaceholder('unique-agent-id').fill('remote-created');
+    await modal.getByPlaceholder('My Remote Agent').fill('Remote Created');
+    await modal.locator('select').selectOption('remote-owned');
+    await modal.getByPlaceholder(/home\/user\/project/).fill('/srv/remote-project');
+    await modal.getByRole('button', { name: 'Create Remote Agent' }).click();
+
+    await expect(agentsPanel.locator('.agentListItem', { hasText: 'Remote Created' })).toContainText('remote-owned');
+    expect(backend.agents.get('remote-created')).toMatchObject({
+      relay: true,
+      relayConnectionName: 'remote-owned',
+      cwd: '/srv/remote-project',
+      yolo: true,
+    });
+    expect(backend.acpRequests).toContainEqual(expect.objectContaining({
+      action: 'create-agent',
+      agent: expect.objectContaining({ id: 'remote-created', relayConnectionName: 'remote-owned' }),
+    }));
+  });
+
+  test('covers node setup, add, rename, probe, relay-agent creation, removal, and locked controls', async ({ page }) => {
+    const backend = await installIsolatedBackend(page);
+    await login(page);
+
+    const addResult = await page.evaluate(async () => {
+      const response = await fetch('/api/nodes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'add-node', name: 'owned-node', label: 'Owned Node' }),
+      });
+      return response.json();
+    });
+    expect(addResult).toEqual({ ok: true });
+
+    await page.locator('button[title="Nodes"]').click();
+    const nodesPanel = page.locator('.agentsSidebar').filter({ hasText: 'Nodes' });
+    await expect(nodesPanel.locator('.agentListItem', { hasText: 'Owned Node' })).toBeVisible();
+
+    await nodesPanel.locator('button[title="Add node"]').click();
+    const setup = page.locator('.setupScriptModal');
+    await expect(setup.getByRole('heading', { name: /Node Setup Kit/ })).toBeVisible();
+    await expect(setup.locator('input[type="radio"][value="copilot"]')).toBeChecked();
+    await setup.locator('input[type="radio"][value="agency"]').check();
+    await expect(setup.locator('input[type="radio"][value="agency"]')).toBeChecked();
+    await setup.getByRole('button', { name: 'Close' }).click();
+
+    let ownedRow = nodesPanel.locator('.agentListItem', { hasText: 'owned-node' });
+    await ownedRow.click();
+    await expect(ownedRow.locator('.nodeAvatar')).toHaveAttribute('data-online', '');
+    expect(backend.nodeRequests).toContainEqual({ action: 'check-node', name: 'owned-node' });
+
+    await ownedRow.locator('.nodeListName').dblclick();
+    const rename = ownedRow.locator('.nodeEditInput');
+    await rename.fill('Renamed Owned Node');
+    await rename.press('Enter');
+    await expect(ownedRow.locator('.nodeListName')).toHaveText('Renamed Owned Node');
+    expect(backend.nodes.get('owned-node')?.label).toBe('Renamed Owned Node');
+
+    const lockedRow = nodesPanel.locator('.agentListItem', { hasText: 'Locked Node' });
+    await expect(lockedRow.locator('.nodeActionBtn')).toHaveCount(0);
+    await expect(lockedRow.locator('.nodeRemoveBtn')).toHaveCount(0);
+    await lockedRow.locator('.nodeListName').dblclick();
+    await expect(lockedRow.locator('.nodeEditInput')).toHaveCount(0);
+
+    ownedRow = nodesPanel.locator('.agentListItem', { hasText: 'owned-node' });
+    await ownedRow.hover();
+    await ownedRow.locator('[title="Add agent on this node"]').click();
+    const relayModal = page.locator('.agentSettingsModal', { hasText: 'Add Agent on owned-node' });
+    await relayModal.getByPlaceholder('unique-agent-id').fill('relay-from-node');
+    await relayModal.getByPlaceholder('My Remote Agent').fill('Relay From Node');
+    await relayModal.getByPlaceholder(/home\/user\/project/).fill('/srv/node-agent');
+    await relayModal.getByRole('button', { name: 'Create Relay Agent' }).click();
+    expect(backend.agents.get('relay-from-node')).toMatchObject({
+      relay: true,
+      relayConnectionName: 'owned-node',
+      cwd: '/srv/node-agent',
+    });
+
+    await ownedRow.hover();
+    await ownedRow.locator('[title="Remove node"]').click();
+    await expect(nodesPanel.locator('.agentListItem', { hasText: 'Renamed Owned Node' })).toHaveCount(0);
+    expect(backend.nodes.has('owned-node')).toBe(false);
+    expect(backend.nodeRequests).toContainEqual({ action: 'remove-node', name: 'owned-node' });
+  });
+});

--- a/tests/agent-node-management.spec.ts
+++ b/tests/agent-node-management.spec.ts
@@ -393,8 +393,11 @@ test.describe('agent and node management', () => {
 
     ownedRow = nodesPanel.locator('.agentListItem', { hasText: 'owned-node' });
     await ownedRow.hover();
-    await ownedRow.locator('[title="Add agent on this node"]').click();
     const relayModal = page.locator('.agentSettingsModal', { hasText: 'Add Agent on owned-node' });
+    await expect(async () => {
+      await ownedRow.locator('[title="Add agent on this node"]').click();
+      await expect(relayModal).toBeVisible({ timeout: 1_000 });
+    }).toPass({ timeout: 5_000 });
     await relayModal.getByPlaceholder('unique-agent-id').fill('relay-from-node');
     await relayModal.getByPlaceholder('My Remote Agent').fill('Relay From Node');
     await relayModal.getByPlaceholder(/home\/user\/project/).fill('/srv/node-agent');

--- a/tests/chat-search.spec.ts
+++ b/tests/chat-search.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+type Chat = {
+  id: string;
+  name: string;
+  ts: number;
+  messages: Array<{ id: string; type: 'user' | 'agent'; content: string; ts: number }>;
+  agentSessions: Record<string, string>;
+};
+
+const chats: Chat[] = [
+  {
+    id: 'search-name',
+    name: 'Quarterly roadmap',
+    ts: 300,
+    messages: [{ id: 'n1', type: 'user', content: 'Plan the next release', ts: 301 }],
+    agentSessions: {},
+  },
+  {
+    id: 'search-message',
+    name: 'Support notes',
+    ts: 200,
+    messages: [{ id: 'm1', type: 'agent', content: 'The hidden keyword is nebula.', ts: 201 }],
+    agentSessions: {},
+  },
+  {
+    id: 'search-other',
+    name: 'Lunch ideas',
+    ts: 100,
+    messages: [{ id: 'o1', type: 'user', content: 'Pick a restaurant', ts: 101 }],
+    agentSessions: {},
+  },
+];
+
+async function mockIsolatedApp(page: Page, searchRequests: string[]) {
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.action === 'list-agents') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          agents: [{ id: 'search-agent', name: 'Search Agent', relay: true, canTalk: true, models: [] }],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+  await page.route('**/api/chats**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== 'GET') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    const id = url.searchParams.get('id');
+    if (id) {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, chat: chats.find((chat) => chat.id === id) }),
+      });
+      return;
+    }
+    const search = url.searchParams.get('search');
+    if (search !== null) {
+      searchRequests.push(url.pathname + url.search);
+      const needle = search.trim().toLowerCase();
+      const results = chats
+        .filter((chat) =>
+          chat.name.toLowerCase().includes(needle)
+          || chat.messages.some((message) => message.content.toLowerCase().includes(needle)),
+        )
+        .map(({ id: chatId, name, ts }) => ({ id: chatId, name, ts }));
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, chats: results }),
+      });
+      return;
+    }
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        chats: chats.map(({ id: chatId, name, ts }) => ({ id: chatId, name, ts })),
+        lastChatId: chats[0].id,
+      }),
+    });
+  });
+}
+
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await expect(page.getByLabel('Search chat history')).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('.message.user')).toBeVisible();
+}
+
+test.describe('chat sidebar keyword search', () => {
+  test('matches a chat name and clear restores the complete history', async ({ page }) => {
+    const requests: string[] = [];
+    await mockIsolatedApp(page, requests);
+    await login(page);
+
+    const search = page.getByLabel('Search chat history');
+    await search.fill('roadmap');
+
+    await expect.poll(() => requests).toContain('/api/chats?search=roadmap');
+    await expect(page.locator('.chatHistoryName')).toHaveText(['Quarterly roadmap']);
+
+    await page.getByRole('button', { name: 'Clear search' }).click();
+    await expect(search).toHaveValue('');
+    await expect(page.locator('.chatHistoryName')).toHaveText([
+      'Quarterly roadmap',
+      'Support notes',
+      'Lunch ideas',
+    ]);
+  });
+
+  test('uses /api/chats?search and displays a message-content match', async ({ page }) => {
+    const requests: string[] = [];
+    await mockIsolatedApp(page, requests);
+    await login(page);
+
+    await page.getByLabel('Search chat history').fill('nebula');
+
+    await expect.poll(() => requests).toContain('/api/chats?search=nebula');
+    await expect(page.locator('.chatHistoryName')).toHaveText(['Support notes']);
+    await expect(page.locator('.chatHistoryName')).not.toContainText('nebula');
+  });
+
+  test('shows the no-results state for an unmatched keyword', async ({ page }) => {
+    const requests: string[] = [];
+    await mockIsolatedApp(page, requests);
+    await login(page);
+
+    await page.getByLabel('Search chat history').fill('does-not-exist');
+
+    await expect.poll(() => requests).toContain('/api/chats?search=does-not-exist');
+    await expect(page.getByText('No chats found', { exact: true })).toBeVisible();
+    await expect(page.locator('.chatHistoryItem')).toHaveCount(0);
+  });
+});
+
+test('search API finds persisted message content and excludes unrelated chats', async ({ page }) => {
+  const suffix = Date.now();
+  const matchingId = `search-api-match-${suffix}`;
+  const unrelatedId = `search-api-other-${suffix}`;
+  const keyword = `quasar-${suffix}`;
+
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON();
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForSelector('.emptyHomepage, .chatContainer', { timeout: 30_000 });
+
+  try {
+    const result = await page.evaluate(async ({ matchingId, unrelatedId, keyword }) => {
+      const save = async (chat: Record<string, unknown>) => {
+        const response = await fetch('/api/chats', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat }),
+        });
+        if (!response.ok) throw new Error(`save failed: ${response.status}`);
+      };
+      await save({
+        id: matchingId,
+        name: 'Opaque matching chat',
+        ts: Date.now(),
+        messages: [{ id: 'message-match', type: 'agent', content: `Stored content contains ${keyword}`, ts: Date.now() }],
+        agentSessions: {},
+      });
+      await save({
+        id: unrelatedId,
+        name: 'Unrelated persisted chat',
+        ts: Date.now() - 1,
+        messages: [{ id: 'message-other', type: 'user', content: 'No matching content', ts: Date.now() }],
+        agentSessions: {},
+      });
+      return fetch(`/api/chats?search=${encodeURIComponent(keyword)}`).then((response) => response.json());
+    }, { matchingId, unrelatedId, keyword });
+
+    expect(result.ok).toBe(true);
+    expect(result.chats.map((chat: { id: string }) => chat.id)).toContain(matchingId);
+    expect(result.chats.map((chat: { id: string }) => chat.id)).not.toContain(unrelatedId);
+  } finally {
+    await page.evaluate(async (ids) => {
+      await Promise.all(ids.map((id) => fetch(`/api/chats?id=${encodeURIComponent(id)}`, { method: 'DELETE' })));
+    }, [matchingId, unrelatedId]);
+  }
+});

--- a/tests/interaction-coverage.spec.ts
+++ b/tests/interaction-coverage.spec.ts
@@ -1,0 +1,378 @@
+import { expect, Page, test } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+const alphaAgent = {
+  id: 'alpha',
+  name: 'Alpha Agent',
+  command: 'mock',
+  args: ['--acp'],
+  cwd: '/tmp',
+  running: true,
+  canTalk: true,
+  canModify: true,
+  public: true,
+  models: [],
+};
+
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.locator('input[placeholder="Admin username"]').fill('admin');
+  await page.locator('input[placeholder="Password"]').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
+  await page.waitForTimeout(500);
+}
+
+async function createFreshChat(page: Page) {
+  await page.locator('button.emptyHomepageNewChat').click();
+  await page.waitForSelector('.chatContainer', { timeout: 10000 });
+}
+
+test.beforeEach(async ({ page }) => {
+  const chats = new Map<string, any>();
+  let lastChatId = '';
+  await page.route('**/api/chats**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() === 'GET') {
+      const id = url.searchParams.get('id');
+      if (id) {
+        const chat = chats.get(id);
+        await route.fulfill({
+          status: chat ? 200 : 404,
+          contentType: 'application/json',
+          body: JSON.stringify(chat ? { ok: true, chat } : { ok: false, error: 'not_found' }),
+        });
+        return;
+      }
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          chats: [...chats.values()].map(({ id: chatId, name, ts }) => ({ id: chatId, name, ts })),
+          lastChatId,
+        }),
+      });
+      return;
+    }
+    if (request.method() === 'POST') {
+      const body = request.postDataJSON();
+      if (body?.chat) chats.set(body.chat.id, body.chat);
+      if (body?.action === 'set-last-chat') lastChatId = body.chatId || '';
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    if (request.method() === 'DELETE') {
+      chats.delete(url.searchParams.get('id') || '');
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    await route.fulfill({ status: 405, contentType: 'application/json', body: JSON.stringify({ ok: false }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+});
+
+test('slash command palette filters and inserts an advertised command', async ({ page }) => {
+  const slashRequests: any[] = [];
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    if (body?.action === 'list-agents') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, agents: [alphaAgent] }) });
+      return;
+    }
+    if (body?.action === 'get-slash-commands') {
+      slashRequests.push(body);
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          commands: [
+            { name: 'review', description: 'Review the current changes', hint: '<scope>' },
+            { name: 'test', description: 'Run tests' },
+          ],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await login(page);
+  await createFreshChat(page);
+  const textarea = page.locator('textarea.composerTextarea');
+  await textarea.fill('/rev');
+
+  const palette = page.getByRole('listbox', { name: 'Slash commands' });
+  await expect(palette).toBeVisible();
+  await expect(palette.getByRole('option')).toHaveCount(1);
+  await expect(palette).toContainText('/review <scope>');
+  await palette.getByRole('option').click();
+
+  await expect(textarea).toHaveValue('/review ');
+  expect(slashRequests.some((request) => request.agentId === 'alpha' && /^chat-/.test(request.chatId))).toBe(true);
+});
+
+test('agent authentication control submits the selected ACP method', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const authRequests: any[] = [];
+  const authAgent = {
+    ...alphaAgent,
+    needsAuth: true,
+    authMethods: [{ id: 'github', name: 'GitHub', description: 'Sign in with GitHub' }],
+  };
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    if (body?.action === 'list-agents') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, agents: [authAgent] }) });
+      return;
+    }
+    if (body?.action === 'acp-authenticate') {
+      authRequests.push(body);
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await login(page);
+  await page.locator('button[title="Agents"]').click();
+  await expect(page.locator('.agentsSidebar')).toBeVisible();
+  await page.getByTitle('Alpha Agent needs authentication').click();
+  const authMenu = page.getByRole('menu');
+  await expect(authMenu).toContainText('Authenticate Alpha Agent');
+  await authMenu.getByRole('menuitem', { name: /GitHub/ }).click();
+
+  await expect.poll(() => authRequests).toEqual([
+    expect.objectContaining({ action: 'acp-authenticate', agentId: 'alpha', methodId: 'github' }),
+  ]);
+  await expect(page.locator('.agentAuthSuccess')).toHaveText('✓ Authenticated');
+});
+
+test('multi-agent composer exposes and switches orchestration modes', async ({ page }) => {
+  const betaAgent = { ...alphaAgent, id: 'beta', name: 'Beta Agent' };
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    if (body?.action === 'list-agents') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, agents: [alphaAgent, betaAgent] }) });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await login(page);
+  await createFreshChat(page);
+  await page.locator('textarea.composerTextarea').fill('@alpha @beta compare approaches');
+
+  const auto = page.getByRole('button', { name: /Auto/ });
+  const pipeline = page.getByRole('button', { name: /Pipeline/ });
+  await expect(auto).toBeVisible();
+  await expect(pipeline).toBeVisible();
+  await expect(page.getByRole('button', { name: /workflow/i })).toBeVisible();
+  await pipeline.click();
+  await expect(pipeline).toHaveClass(/orchPillActive/);
+  await expect(auto).not.toHaveClass(/orchPillActive/);
+});
+
+test('pipeline orchestration runs agents sequentially and summarizes their results', async ({ page }) => {
+  const betaAgent = { ...alphaAgent, id: 'beta', name: 'Beta Agent' };
+  const sends: any[] = [];
+  const activeTurns = new Map<string, { id: string; text: string }>();
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    if (body?.action === 'list-agents') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, agents: [alphaAgent, betaAgent] }) });
+      return;
+    }
+    if (body?.action === 'send') {
+      sends.push(body);
+      const id = `turn-${body.agentId}-${sends.length}`;
+      const text = body.agentId === 'beta' ? 'Beta builds on Alpha' : sends.length === 1 ? 'Alpha initial result' : 'Alpha final summary';
+      activeTurns.set(body.agentId, { id, text });
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, phase: 'thinking', sessionId: `session-${body.agentId}`, turn: { id } }),
+      });
+      return;
+    }
+    if (body?.action === 'poll') {
+      const turn = activeTurns.get(body.agentId);
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          phase: 'idle',
+          ready: true,
+          booting: false,
+          activeTurn: turn ? {
+            id: turn.id,
+            fullText: turn.text,
+            done: true,
+            phase: 'done',
+            events: [{ type: 'text_chunk', ts: Date.now(), text: turn.text }],
+          } : null,
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await login(page);
+  await createFreshChat(page);
+  const textarea = page.locator('textarea.composerTextarea');
+  await textarea.fill('@alpha @beta produce a joint answer');
+  await page.getByRole('button', { name: /Pipeline/ }).click();
+  await page.getByRole('button', { name: 'Send message' }).click();
+
+  await expect.poll(() => sends.map((request) => request.agentId), { timeout: 20000 })
+    .toEqual(['alpha', 'beta', 'alpha']);
+  expect(sends[0].text).toContain('produce a joint answer');
+  expect(sends[1].text).toContain('Alpha initial result');
+  expect(sends[2].text).toContain('Alpha initial result');
+  expect(sends[2].text).toContain('Beta builds on Alpha');
+  await expect(page.locator('.message.agent', { hasText: 'Alpha final summary' })).toBeVisible();
+});
+
+test('fullscreen control reflects browser fullscreen state', async ({ page }) => {
+  await page.addInitScript(() => {
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, 'fullscreenEnabled', { configurable: true, get: () => true });
+    Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => fullscreenElement });
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: async () => {
+        fullscreenElement = document.documentElement;
+        document.dispatchEvent(new Event('fullscreenchange'));
+      },
+    });
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: async () => {
+        fullscreenElement = null;
+        document.dispatchEvent(new Event('fullscreenchange'));
+      },
+    });
+  });
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [alphaAgent] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+
+  await login(page);
+  const enter = page.getByRole('button', { name: 'Enter full screen' });
+  await expect(enter).toBeVisible();
+  await enter.click();
+  const exit = page.getByRole('button', { name: 'Exit full screen' });
+  await expect(exit).toHaveAttribute('aria-pressed', 'true');
+  await exit.click();
+  await expect(page.getByRole('button', { name: 'Enter full screen' })).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('mobile header exposes primary panels through the overflow menu', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [alphaAgent] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+
+  await login(page);
+  await page.getByRole('button', { name: 'More actions' }).click();
+  const menu = page.getByRole('menu', { name: 'Header actions' });
+  await expect(menu.getByRole('menuitem', { name: 'Chats' })).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'Agents' })).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'Nodes' })).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'Schedules' })).toBeVisible();
+  await menu.getByRole('menuitem', { name: 'Agents' }).click();
+  await expect(page.locator('.agentsSidebar')).toBeVisible();
+});
+
+test('settings persist the remembered agent scope per chat', async ({ page }) => {
+  let scope = 'user';
+  const settingRequests: any[] = [];
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    if (body?.action === 'list-agents') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, agents: [alphaAgent] }) });
+      return;
+    }
+    if (body?.action === 'get-user-settings') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, settings: { last_used_agent_scope: scope } }),
+      });
+      return;
+    }
+    if (body?.action === 'set-user-setting') {
+      settingRequests.push(body);
+      scope = body.value;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await login(page);
+  await page.getByRole('button', { name: 'Settings' }).click();
+  const menu = page.getByRole('menu', { name: 'Settings' });
+  await menu.getByRole('menuitemradio', { name: 'Per chat' }).click();
+  await expect.poll(() => settingRequests).toContainEqual(
+    expect.objectContaining({ action: 'set-user-setting', key: 'last_used_agent_scope', value: 'chat' }),
+  );
+
+  await page.reload();
+  await page.waitForSelector('.emptyHomepage, .chatContainer', { timeout: 30000 });
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await expect(page.getByRole('menu', { name: 'Settings' }).getByRole('menuitemradio', { name: 'Per chat' }))
+    .toHaveAttribute('aria-checked', 'true');
+});
+
+test('dragging a file onto the composer queues it as an attachment', async ({ page }) => {
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [alphaAgent] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+
+  await login(page);
+  await createFreshChat(page);
+  await page.locator('.composerShell').evaluate((composer) => {
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(['dragged content'], 'dragged.txt', { type: 'text/plain' }));
+    composer.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    composer.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: transfer }));
+  });
+  await expect(page.locator('.attachmentChip', { hasText: 'dragged.txt' })).toBeVisible();
+});
+
+test('file endpoint enforces auth, blocks sensitive paths, and report validates its path', async ({ page, request }) => {
+  const unauthorized = await request.get(`${BASE}/api/file`);
+  expect(unauthorized.status()).toBe(401);
+
+  await login(page);
+  const missing = await page.request.get(`${BASE}/api/file`);
+  expect(missing.status()).toBe(400);
+  await expect(missing.json()).resolves.toEqual({ error: 'missing path param' });
+
+  const blocked = await page.request.get(`${BASE}/api/file?path=${encodeURIComponent('/etc/passwd')}`);
+  expect(blocked.status()).toBe(403);
+  await expect(blocked.json()).resolves.toEqual({ error: 'blocked path' });
+
+  const absent = await page.request.get(`${BASE}/api/file?path=${encodeURIComponent('/tmp/agents-chat-does-not-exist.html')}`);
+  expect(absent.status()).toBe(404);
+
+  await page.goto(`${BASE}/report`);
+  await expect(page.getByText('Missing')).toBeVisible();
+  await expect(page.locator('code')).toHaveText('?path=');
+
+  const safePath = `${process.cwd()}/package.json`;
+  const allowed = await page.request.get(`${BASE}/api/file?path=${encodeURIComponent(safePath)}`);
+  expect(allowed.status()).toBe(200);
+  expect(allowed.headers()['content-type']).toContain('application/json');
+  expect((await allowed.json()).name).toBe('agents-chat');
+
+  await page.goto(`${BASE}/report?path=${encodeURIComponent(safePath)}`);
+  await expect(page.getByTitle('Report')).toHaveAttribute('src', `/api/file?path=${encodeURIComponent(safePath)}`);
+});

--- a/tests/scheduler-advanced.spec.ts
+++ b/tests/scheduler-advanced.spec.ts
@@ -1,0 +1,225 @@
+import { expect, Page, test } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+const alphaAgent = {
+  id: 'alpha',
+  name: 'Alpha Agent',
+  command: 'mock',
+  args: ['--acp'],
+  cwd: '/tmp',
+  running: true,
+  canTalk: true,
+  canModify: true,
+  public: true,
+  models: [],
+};
+
+type ScheduleJob = {
+  id: string;
+  agentId: string;
+  ownerEmail: string;
+  name: string;
+  prompt: string;
+  scheduleSpec: Record<string, unknown>;
+  cronExpr: string;
+  enabled: boolean;
+  timeoutMinutes: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+async function mockApp(page: Page, initialJobs: ScheduleJob[] = []) {
+  const jobs = [...initialJobs];
+  const runs = new Map<string, any[]>();
+  const createRequests: any[] = [];
+  const runRequests: string[] = [];
+
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [alphaAgent] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+  await page.route('**/api/chats**', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, chats: [], lastChatId: '' }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+  await page.route('**/api/schedules**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const segments = url.pathname.split('/').filter(Boolean);
+    const id = segments[2];
+    const isRun = segments[3] === 'run';
+
+    if (request.method() === 'GET' && !id) {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ jobs }) });
+      return;
+    }
+    if (request.method() === 'POST' && !id) {
+      const body = request.postDataJSON();
+      createRequests.push(body);
+      const job: ScheduleJob = {
+        id: `schedule-${jobs.length + 1}`,
+        ownerEmail: 'admin',
+        cronExpr: '* * * * *',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        ...body,
+      };
+      jobs.push(job);
+      await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ job, id: job.id }) });
+      return;
+    }
+    if (request.method() === 'POST' && id && isRun) {
+      runRequests.push(id);
+      const run = {
+        id: `run-${runRequests.length + 2}`,
+        jobId: id,
+        status: 'success',
+        scheduledFor: Date.now(),
+        startedAt: Date.now(),
+        finishedAt: Date.now() + 100,
+        replyText: 'Run-now reply',
+      };
+      runs.set(id, [run, ...(runs.get(id) || [])]);
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ run }) });
+      return;
+    }
+    if (request.method() === 'GET' && id) {
+      const job = jobs.find((item) => item.id === id);
+      await route.fulfill({
+        status: job ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(job ? { job, runs: runs.get(id) || [] } : { error: 'not found' }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  return { jobs, runs, createRequests, runRequests };
+}
+
+async function login(page: Page) {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForSelector('.emptyHomepage, .chatContainer', { timeout: 30000 });
+  await page.waitForTimeout(500);
+}
+
+async function openSchedules(page: Page) {
+  await page.locator('button[title="Schedules"]').click();
+  await expect(page.locator('.agentsSidebar', { hasText: 'Schedules' })).toBeVisible();
+}
+
+test('scheduler creates a weekly local-time job with timeout and selected weekdays', async ({ page }) => {
+  const { createRequests } = await mockApp(page);
+  await login(page);
+  await openSchedules(page);
+  await page.getByTitle('Create schedule').click();
+
+  const modal = page.locator('.agentSettingsModal');
+  await modal.getByPlaceholder('E.g., Daily report generation').fill('Weekly review');
+  await modal.getByPlaceholder('What should the agent do?').fill('Review the weekly changes');
+
+  await modal.getByRole('button', { name: 'Schedule Type' }).click();
+  await page.locator('.themedPickerDropdown[aria-label="Schedule Type"]')
+    .locator('button.themedPickerOption[data-value="weekly"]')
+    .click();
+  await modal.getByLabel('Mon', { exact: true }).check();
+  await modal.getByLabel('Wed', { exact: true }).check();
+  await modal.getByLabel('Hour (0-23)').fill('14');
+  await modal.getByLabel('Minute (0-59)').fill('30');
+  await modal.getByLabel(/Run timeout/).fill('45');
+  await modal.getByRole('button', { name: 'Save' }).click();
+
+  await expect(modal).toBeHidden();
+  await expect(page.locator('.scheduleListItem', { hasText: 'Weekly review' })).toBeVisible();
+  const expectedUtc = await page.evaluate(() => {
+    let total = 14 * 60 + 30 + new Date().getTimezoneOffset();
+    let dayShift = 0;
+    while (total < 0) {
+      total += 24 * 60;
+      dayShift -= 1;
+    }
+    while (total >= 24 * 60) {
+      total -= 24 * 60;
+      dayShift += 1;
+    }
+    const shiftDay = (day: number) => ((day + dayShift) % 7 + 7) % 7;
+    return { hour: Math.floor(total / 60), minute: total % 60, weekdays: [shiftDay(1), shiftDay(3)] };
+  });
+  expect(createRequests).toHaveLength(1);
+  expect(createRequests[0]).toMatchObject({
+    agentId: 'alpha',
+    name: 'Weekly review',
+    prompt: 'Review the weekly changes',
+    enabled: true,
+    timeoutMinutes: 45,
+    scheduleSpec: { kind: 'weekly', ...expectedUtc },
+  });
+});
+
+test('scheduler displays run history and refreshes after Run now', async ({ page }) => {
+  const job: ScheduleJob = {
+    id: 'history-job',
+    agentId: 'alpha',
+    ownerEmail: 'admin',
+    name: 'History coverage',
+    prompt: 'Run history',
+    scheduleSpec: { kind: 'daily', hour: 9, minute: 15 },
+    cronExpr: '15 9 * * *',
+    enabled: true,
+    timeoutMinutes: 10,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+  const { runs, runRequests } = await mockApp(page, [job]);
+  runs.set(job.id, [
+    {
+      id: 'run-success',
+      jobId: job.id,
+      status: 'success',
+      scheduledFor: 1_700_000_000_000,
+      startedAt: 1_700_000_000_000,
+      finishedAt: 1_700_000_001_500,
+      replyText: 'Scheduled reply',
+    },
+    {
+      id: 'run-error',
+      jobId: job.id,
+      status: 'error',
+      scheduledFor: 1_699_999_000_000,
+      startedAt: 1_699_999_000_000,
+      finishedAt: 1_699_999_000_500,
+      errorMessage: 'Agent unavailable',
+    },
+  ]);
+
+  await login(page);
+  await openSchedules(page);
+  await page.locator('.scheduleListItem', { hasText: job.name }).getByTitle('View run history').click();
+
+  const modal = page.locator('.agentSettingsModal');
+  await expect(modal.getByRole('heading')).toContainText('History coverage — Runs');
+  await modal.locator('details').first().locator('summary').click();
+  await expect(modal).toContainText('Scheduled reply');
+  await modal.locator('details').nth(1).locator('summary').click();
+  await expect(modal).toContainText('Agent unavailable');
+
+  await modal.getByRole('button', { name: '▶ Run now' }).click();
+  await expect.poll(() => runRequests).toEqual([job.id]);
+  await expect(modal).toContainText('Run-now reply');
+});

--- a/tests/share-flow.spec.ts
+++ b/tests/share-flow.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+type Chat = {
+  id: string;
+  name: string;
+  ts: number;
+  messages: Array<{ id: string; type: 'user' | 'agent'; content: string; agentId?: string; ts: number }>;
+  agentSessions: Record<string, string>;
+};
+
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await expect(page.locator('.chatHistoryItem')).toBeVisible({ timeout: 30_000 });
+}
+
+test('creates, copies, closes, renders, and continues a shared conversation', async ({ page, context }) => {
+  const source: Chat = {
+    id: 'share-source',
+    name: 'Deterministic shared chat',
+    ts: 500,
+    messages: [
+      { id: 'share-user', type: 'user', content: 'Please preserve this question.', ts: 501 },
+      { id: 'share-agent', type: 'agent', agentId: 'share-agent', content: 'Preserved answer.', ts: 502 },
+    ],
+    agentSessions: {},
+  };
+  const chats = new Map<string, Chat>([[source.id, source]]);
+  let lastChatId = source.id;
+  const shareRequests: Record<string, unknown>[] = [];
+  const shareId = 'share-e2e-fixed';
+
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: new URL(BASE).origin });
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.action === 'list-agents') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          agents: [{ id: 'share-agent', name: 'Share Agent', relay: true, canTalk: true, models: [] }],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+  await page.route('**/api/chats**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() === 'GET') {
+      const id = url.searchParams.get('id');
+      const chat = id ? chats.get(id) : undefined;
+      await route.fulfill({
+        contentType: 'application/json',
+        status: id && !chat ? 404 : 200,
+        body: JSON.stringify(id
+          ? (chat ? { ok: true, chat } : { ok: false, error: 'not_found' })
+          : {
+              ok: true,
+              chats: [...chats.values()].map(({ id: chatId, name, ts }) => ({ id: chatId, name, ts })),
+              lastChatId,
+            }),
+      });
+      return;
+    }
+    const body = request.postDataJSON();
+    if (body?.action === 'set-last-chat') lastChatId = body.chatId;
+    if (body?.chat) chats.set(body.chat.id, body.chat);
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/share**', async (route) => {
+    const request = route.request();
+    if (request.method() === 'GET') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          chat: {
+            shareId,
+            sharedBy: 'admin@local',
+            sharedAt: 1_700_000_000_000,
+            name: source.name,
+            messages: source.messages,
+          },
+        }),
+      });
+      return;
+    }
+    const body = request.postDataJSON();
+    shareRequests.push(body);
+    if (body?.action === 'import') {
+      const imported: Chat = {
+        ...source,
+        id: 'shared-import-fixed',
+        ts: 600,
+        agentSessions: {},
+      };
+      chats.set(imported.id, imported);
+      lastChatId = imported.id;
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, chatId: imported.id }),
+      });
+      return;
+    }
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, shareId, url: `/share/${shareId}` }),
+    });
+  });
+
+  await login(page);
+  const row = page.locator('.chatHistoryRow', { hasText: source.name });
+  await row.hover();
+  await row.locator('.chatMoreBtn').click();
+  await page.getByRole('menuitem', { name: 'Share' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Share this conversation' });
+  await expect(dialog).toBeVisible();
+  const expectedUrl = `${new URL(BASE).origin}/share/${shareId}`;
+  await expect(dialog.locator('.shareLinkInput')).toHaveValue(expectedUrl);
+  expect(shareRequests[0]).toEqual({ chatId: source.id });
+
+  await dialog.getByRole('button', { name: 'Copy' }).click();
+  await expect(dialog.getByRole('button', { name: 'Copied' })).toBeVisible();
+  await expect(dialog.getByText('Copied to clipboard.')).toBeVisible();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(expectedUrl);
+  await dialog.getByRole('button', { name: 'Close' }).click();
+  await expect(dialog).toBeHidden();
+
+  await page.goto(expectedUrl);
+  await expect(page.getByRole('heading', { name: `🤖 ${source.name}` })).toBeVisible();
+  await expect(page.locator('.shareMsg.user')).toContainText('Please preserve this question.');
+  await expect(page.locator('.shareMsg.agent')).toContainText('Preserved answer.');
+
+  await page.getByRole('button', { name: '💬 Continue this conversation' }).click();
+  await expect(page).toHaveURL(new URL('/', BASE).toString());
+  await expect(page.locator('.message.user')).toContainText('Please preserve this question.');
+  await expect(page.locator('.message.agent')).toContainText('Preserved answer.');
+  expect(shareRequests.at(-1)).toEqual({ action: 'import', shareId });
+});

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -1924,8 +1924,7 @@ test.describe('Chat UI', () => {
       await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
     });
     await page.reload();
-    await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
-    await ensureActiveChat(page);
+    await page.waitForSelector('.chatContainer', { timeout: 30000 });
     const textarea = page.locator('textarea.composerTextarea');
     const chatArea = page.locator('.chatContainer');
 
@@ -1948,7 +1947,8 @@ test.describe('Chat UI', () => {
     await expect(chatArea.locator('.message.system:has-text("created")')).toBeVisible({ timeout: 30000 });
 
     // Step 3: Switch back to the old chat
-    const oldChat = page.locator('.chatHistoryItem:not(.active)').first();
+    const oldChat = page.locator('.chatHistoryItem', { hasText: 'Let a = 1 + 1' });
+    await expect(oldChat).toBeVisible({ timeout: 15000 });
     await oldChat.click();
 
     // Verify: old messages are visible IN THE CHAT AREA after switching

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -29,21 +29,23 @@ async function login(page: Page) {
 
 /** Delete all existing chats via the API so each test starts clean */
 async function deleteAllChats(page: Page) {
-  const res = await page.evaluate(async () => {
-    const r = await fetch('/api/chats');
-    return r.json();
-  });
-  if (res?.ok && Array.isArray(res.chats)) {
-    for (const chat of res.chats) {
-      await page.evaluate(async (id: string) => {
-        await fetch(`/api/chats?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
-      }, chat.id);
-    }
+  // Unmount the chat runtime first so an in-flight persistence effect cannot
+  // recreate a chat while the test fixture is deleting it.
+  await page.goto('about:blank');
+  const request = page.context().request;
+  const listResponse = await request.get(`${BASE}/api/chats`);
+  expect(listResponse.ok()).toBeTruthy();
+  const res = await listResponse.json();
+
+  for (const chat of res.chats ?? []) {
+    const deleteResponse = await request.delete(`${BASE}/api/chats?id=${encodeURIComponent(chat.id)}`);
+    expect(deleteResponse.ok()).toBeTruthy();
   }
-  // Clear lastChatId on the server so page reload shows empty homepage
-  await page.evaluate(async () => {
-    await fetch('/api/chats', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'set-last-chat', chatId: '' }) });
+  const clearResponse = await request.post(`${BASE}/api/chats`, {
+    data: { action: 'set-last-chat', chatId: '' },
   });
+  expect(clearResponse.ok()).toBeTruthy();
+  await page.goto(BASE);
 }
 
 /** Ensure an active chat exists — clicks "+ New Chat" if on empty homepage */

--- a/tests/workflow-library.spec.ts
+++ b/tests/workflow-library.spec.ts
@@ -1,0 +1,267 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+type Plan = {
+  name?: string;
+  version: 1;
+  nodes: Array<{ id: string; agent: string; instruction: string; dependsOn: string[] }>;
+};
+
+type UserWorkflow = { id: string; name: string; plan: Plan; createdAt: number; updatedAt: number };
+
+const repoPlan: Plan = {
+  name: 'Repository Review',
+  version: 1,
+  nodes: [{ id: 'review', agent: 'alpha', instruction: 'Review {{input}}', dependsOn: [] }],
+};
+const savedPlan: Plan = {
+  name: 'Saved Triage',
+  version: 1,
+  nodes: [{ id: 'triage', agent: 'beta', instruction: 'Triage {{input}}', dependsOn: [] }],
+};
+const suggestedPlan: Plan = {
+  name: 'Suggested Plan',
+  version: 1,
+  nodes: [{ id: 'suggest', agent: 'alpha', instruction: 'Investigate {{input}}', dependsOn: [] }],
+};
+
+async function mockIsolatedApp(page: Page) {
+  const userWorkflows = new Map<string, UserWorkflow>([
+    ['saved-triage', { id: 'saved-triage', name: 'Saved Triage', plan: savedPlan, createdAt: 10, updatedAt: 10 }],
+  ]);
+  const workflowRequests: Array<{ method: string; path: string; body?: unknown }> = [];
+  const chat = {
+    id: 'workflow-chat',
+    name: 'Workflow coverage',
+    ts: 700,
+    messages: [
+      { id: 'wf-user', type: 'user', content: 'Create a reusable workflow.', ts: 701 },
+      {
+        id: 'wf-agent',
+        type: 'agent',
+        agentId: 'alpha',
+        content: `\`\`\`json\n${JSON.stringify(suggestedPlan, null, 2)}\n\`\`\``,
+        ts: 702,
+      },
+    ],
+    agentSessions: {},
+  };
+
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.action === 'list-agents') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          agents: [
+            { id: 'alpha', name: 'Alpha', relay: true, canTalk: true, models: [] },
+            { id: 'beta', name: 'Beta', relay: true, canTalk: true, models: [] },
+          ],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+  await page.route('**/api/chats**', async (route) => {
+    const request = route.request();
+    const id = new URL(request.url()).searchParams.get('id');
+    if (request.method() === 'GET') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(id
+          ? { ok: true, chat }
+          : { ok: true, chats: [{ id: chat.id, name: chat.name, ts: chat.ts }], lastChatId: chat.id }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/workflows', async (route) => {
+    const request = route.request();
+    workflowRequests.push({
+      method: request.method(),
+      path: new URL(request.url()).pathname,
+      body: request.method() === 'POST' ? request.postDataJSON() : undefined,
+    });
+    if (request.method() === 'GET') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          repo: [{ name: repoPlan.name, source: 'repo', filePath: '.github/workflows/review.json', plan: repoPlan }],
+          user: [...userWorkflows.values()],
+        }),
+      });
+      return;
+    }
+    const body = request.postDataJSON();
+    const id = body.id || 'saved-from-message';
+    const workflow: UserWorkflow = {
+      id,
+      name: body.name,
+      plan: body.plan,
+      createdAt: 20,
+      updatedAt: 20,
+    };
+    userWorkflows.set(id, workflow);
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, workflow }) });
+  });
+  await page.route('**/api/workflows/**', async (route) => {
+    const request = route.request();
+    const id = decodeURIComponent(new URL(request.url()).pathname.split('/').pop() || '');
+    workflowRequests.push({ method: request.method(), path: new URL(request.url()).pathname });
+    const workflow = userWorkflows.get(id);
+    if (request.method() === 'DELETE') {
+      const deleted = userWorkflows.delete(id);
+      await route.fulfill({
+        status: deleted ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(deleted ? { ok: true } : { ok: false, error: 'not_found' }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: workflow ? 200 : 404,
+      contentType: 'application/json',
+      body: JSON.stringify(workflow ? { ok: true, workflow } : { ok: false, error: 'not_found' }),
+    });
+  });
+
+  return { userWorkflows, workflowRequests };
+}
+
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await expect(page.getByRole('button', { name: 'workflow', exact: true })).toBeVisible({ timeout: 30_000 });
+}
+
+async function openPicker(page: Page) {
+  await page.getByRole('button', { name: /^workflow(?::|$)/ }).click();
+  await expect(page.getByRole('heading', { name: 'Pick a workflow' })).toBeVisible();
+}
+
+test.describe('workflow library', () => {
+  test('loads repo and user workflows and selects each from the picker', async ({ page }) => {
+    const { workflowRequests } = await mockIsolatedApp(page);
+    await login(page);
+
+    await openPicker(page);
+    await expect(page.getByRole('heading', { name: 'Repo workflows' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Saved workflows' })).toBeVisible();
+    await page.getByRole('button', { name: /Repository Review 1 nodes/ }).click();
+    await expect(page.getByRole('button', { name: 'workflow: Repository Review' })).toBeVisible();
+
+    await openPicker(page);
+    await page.getByRole('button', { name: /Saved Triage 1 nodes/ }).click();
+    await expect(page.getByRole('button', { name: 'workflow: Saved Triage' })).toBeVisible();
+    expect(workflowRequests.filter((request) => request.method === 'GET').length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('reports invalid JSON and builds a selectable template with available agents', async ({ page }) => {
+    await mockIsolatedApp(page);
+    await login(page);
+    await openPicker(page);
+
+    const editor = page.locator('.wfPickerModal textarea');
+    await editor.fill('{ invalid json');
+    await page.getByRole('button', { name: 'Use this plan' }).click();
+    await expect(page.locator('.wfPickerError')).toContainText('Invalid JSON:');
+
+    await page.getByRole('button', { name: 'Use template' }).click();
+    await expect(editor).toContainText('"name": "my-workflow"');
+    await expect(editor).toContainText('"agent": "alpha"');
+    await expect(editor).toContainText('"agent": "beta"');
+    await page.getByRole('button', { name: 'Use this plan' }).click();
+    await expect(page.getByRole('button', { name: 'workflow: my-workflow' })).toBeVisible();
+  });
+
+  test('saves from chat UI, reloads it in the picker, and deletes it through the API', async ({ page }) => {
+    const { userWorkflows, workflowRequests } = await mockIsolatedApp(page);
+    await login(page);
+
+    page.once('dialog', (dialog) => dialog.accept('Saved from E2E'));
+    await page.getByRole('button', { name: 'Save as workflow' }).click();
+    await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
+    expect(userWorkflows.get('saved-from-message')?.name).toBe('Saved from E2E');
+
+    await openPicker(page);
+    await expect(page.getByRole('button', { name: /Saved from E2E 1 nodes/ })).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    const apiResult = await page.evaluate(async () => {
+      const loaded = await fetch('/api/workflows/saved-from-message').then((response) => response.json());
+      const deleted = await fetch('/api/workflows/saved-from-message', { method: 'DELETE' })
+        .then((response) => response.json());
+      return { loaded, deleted };
+    });
+    expect(apiResult.loaded.workflow.name).toBe('Saved from E2E');
+    expect(apiResult.deleted).toEqual({ ok: true });
+    expect(workflowRequests).toContainEqual({ method: 'DELETE', path: '/api/workflows/saved-from-message' });
+
+    await openPicker(page);
+    await expect(page.getByRole('button', { name: /Saved from E2E/ })).toHaveCount(0);
+  });
+});
+
+test('workflow API persists, validates, lists, and deletes a user workflow', async ({ page }) => {
+  const id = `workflow-api-${Date.now()}`;
+  const plan: Plan = {
+    name: 'API Workflow',
+    version: 1,
+    nodes: [{ id: 'step', agent: 'alpha', instruction: 'Process {{input}}', dependsOn: [] }],
+  };
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON();
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+  await page.goto(`${BASE}/login`);
+  await page.getByPlaceholder('Admin username').fill('admin');
+  await page.getByPlaceholder('Password').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForSelector('.emptyHomepage, .chatContainer', { timeout: 30_000 });
+
+  try {
+    const result = await page.evaluate(async ({ id, plan }) => {
+      const request = async (url: string, init?: RequestInit) => {
+        const response = await fetch(url, init);
+        return { status: response.status, body: await response.json() };
+      };
+      const created = await request('/api/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, name: 'API Workflow', plan }),
+      });
+      const loaded = await request(`/api/workflows/${encodeURIComponent(id)}`);
+      const listed = await request('/api/workflows');
+      const invalid = await request('/api/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: `${id}-invalid`,
+          name: 'Invalid workflow',
+          plan: { version: 1, nodes: [{ id: 'broken', agent: '', instruction: '', dependsOn: ['missing'] }] },
+        }),
+      });
+      return { created, loaded, listed, invalid };
+    }, { id, plan });
+
+    expect(result.created.status).toBe(200);
+    expect(result.loaded.body.workflow).toMatchObject({ id, name: 'API Workflow' });
+    expect(result.listed.body.user.some((workflow: { id: string }) => workflow.id === id)).toBe(true);
+    expect(result.invalid.status).toBe(400);
+  } finally {
+    await page.evaluate(async (workflowId) => {
+      await fetch(`/api/workflows/${encodeURIComponent(workflowId)}`, { method: 'DELETE' });
+    }, id);
+  }
+});


### PR DESCRIPTION
## Summary
- add 23 Playwright cases for chat search, shared chats, workflow library, agent/node management, ACP authentication, slash commands, pipeline orchestration, scheduler history and weekly schedules
- cover fullscreen/mobile navigation, settings persistence, drag-and-drop attachments, and file/report security boundaries
- validate chat search and workflow persistence against the real APIs in addition to deterministic UI mocks
- fix mobile header overflow so the tested action menu is visible outside the collapsing header

## Validation
- 23 new tests passed
- expanded suite lists 164 tests, evenly distributed as 41 per CI runner
- TypeScript check passed
- only the existing Azure/Windows opt-in integration cases remain intentionally environment-gated