### PR TITLE
Fix mobile composer viewport sizing

### DIFF
--- a/app/features/agents/components/AgentModelSelect.tsx
+++ b/app/features/agents/components/AgentModelSelect.tsx
@@ -31,25 +31,48 @@ export function AgentModelSelect({
   useLayoutEffect(() => {
     if (!isOpen) return;
 
+    let animationFrame = 0;
     function updatePosition() {
-      const wrap = localWrapRef.current;
-      if (!wrap) return;
-      const rect = wrap.getBoundingClientRect();
-      const minWidth = Math.max(180, rect.width);
-      const left = Math.min(Math.max(8, rect.left), window.innerWidth - minWidth - 8);
-      setDropdownStyle({
-        left,
-        bottom: Math.max(8, window.innerHeight - rect.top + 6),
-        minWidth,
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => {
+        const wrap = localWrapRef.current;
+        if (!wrap) return;
+        const rect = wrap.getBoundingClientRect();
+        const visualViewport = window.visualViewport;
+        const viewportLeft = visualViewport?.offsetLeft ?? 0;
+        const viewportTop = visualViewport?.offsetTop ?? 0;
+        const viewportWidth = visualViewport?.width ?? window.innerWidth;
+        const viewportHeight = visualViewport?.height ?? window.innerHeight;
+        const availableWidth = Math.max(0, viewportWidth - 16);
+        const minWidth = Math.min(Math.max(180, rect.width), availableWidth);
+        const left = Math.min(
+          Math.max(viewportLeft + 8, rect.left),
+          viewportLeft + viewportWidth - minWidth - 8,
+        );
+        const spaceAbove = Math.max(0, rect.top - viewportTop - 14);
+        const spaceBelow = Math.max(0, viewportTop + viewportHeight - rect.bottom - 14);
+        const openAbove = spaceAbove >= 96 || spaceAbove >= spaceBelow;
+        setDropdownStyle({
+          left,
+          top: openAbove ? 'auto' : rect.bottom + 6,
+          bottom: openAbove ? Math.max(8, window.innerHeight - rect.top + 6) : 'auto',
+          minWidth,
+          maxHeight: openAbove ? spaceAbove : spaceBelow,
+        });
       });
     }
 
     updatePosition();
     window.addEventListener('resize', updatePosition);
     window.addEventListener('scroll', updatePosition, true);
+    window.visualViewport?.addEventListener('resize', updatePosition);
+    window.visualViewport?.addEventListener('scroll', updatePosition);
     return () => {
+      cancelAnimationFrame(animationFrame);
       window.removeEventListener('resize', updatePosition);
       window.removeEventListener('scroll', updatePosition, true);
+      window.visualViewport?.removeEventListener('resize', updatePosition);
+      window.visualViewport?.removeEventListener('scroll', updatePosition);
     };
   }, [isOpen]);
 

--- a/app/features/agents/components/AgentModelSelect.tsx
+++ b/app/features/agents/components/AgentModelSelect.tsx
@@ -43,9 +43,16 @@ export function AgentModelSelect({
         const viewportTop = visualViewport?.offsetTop ?? 0;
         const viewportWidth = visualViewport?.width ?? window.innerWidth;
         const viewportHeight = visualViewport?.height ?? window.innerHeight;
+        const portalHost = wrap.closest('.page');
+        const hostRect = portalHost?.getBoundingClientRect() ?? {
+          top: 0,
+          right: window.innerWidth,
+          bottom: window.innerHeight,
+          left: 0,
+        };
         const availableWidth = Math.max(0, viewportWidth - 16);
         const minWidth = Math.min(Math.max(180, rect.width), availableWidth);
-        const left = Math.min(
+        const viewportLeftPosition = Math.min(
           Math.max(viewportLeft + 8, rect.left),
           viewportLeft + viewportWidth - minWidth - 8,
         );
@@ -53,9 +60,9 @@ export function AgentModelSelect({
         const spaceBelow = Math.max(0, viewportTop + viewportHeight - rect.bottom - 14);
         const openAbove = spaceAbove >= 96 || spaceAbove >= spaceBelow;
         setDropdownStyle({
-          left,
-          top: openAbove ? 'auto' : rect.bottom + 6,
-          bottom: openAbove ? Math.max(8, window.innerHeight - rect.top + 6) : 'auto',
+          left: viewportLeftPosition - hostRect.left,
+          top: openAbove ? 'auto' : rect.bottom - hostRect.top + 6,
+          bottom: openAbove ? hostRect.bottom - rect.top + 6 : 'auto',
           minWidth,
           maxHeight: openAbove ? spaceAbove : spaceBelow,
         });

--- a/app/features/agents/components/AgentsPanel.css
+++ b/app/features/agents/components/AgentsPanel.css
@@ -233,7 +233,7 @@
   gap: 2px;
 }
 .chatPageRoot .agentModelDropdownPortal {
-  position: fixed;
+  position: absolute;
   top: auto;
   right: auto;
   bottom: auto;

--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -1,4 +1,5 @@
 .chatPageRoot .page {
+  position: relative;
   height: var(--app-viewport-height, 100dvh);
   min-height: var(--app-viewport-height, 100dvh);
   overflow: hidden;

--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -1,6 +1,6 @@
 .chatPageRoot .page {
-  height: 100vh;
-  min-height: 100vh;
+  height: var(--app-viewport-height, 100dvh);
+  min-height: var(--app-viewport-height, 100dvh);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -1077,13 +1077,24 @@
 }
 
 @media (max-width: 900px) {
+  .chatPageRoot .page {
+    position: fixed;
+    top: var(--app-viewport-offset-top, 0px);
+    right: 0;
+    left: 0;
+    width: 100%;
+  }
   .chatPageRoot .mobileOnlyButton {
     display: inline-flex;
   }
   .chatPageRoot .mobilePanelBackdrop {
     display: block;
     position: fixed;
-    inset: 0;
+    top: var(--app-viewport-offset-top, 0px);
+    right: 0;
+    bottom: auto;
+    left: 0;
+    height: var(--app-viewport-height, 100dvh);
     background: rgba(0, 0, 0, 0.42);
     backdrop-filter: blur(3px);
     z-index: 11;
@@ -1101,8 +1112,9 @@
   .chatPageRoot .agentsSidebar {
     display: block;
     position: fixed;
-    top: 0;
-    bottom: 0;
+    top: var(--app-viewport-offset-top, 0px);
+    bottom: auto;
+    height: var(--app-viewport-height, 100dvh);
     width: min(84vw, 320px);
     z-index: 12;
     box-shadow: var(--shadow);

--- a/app/features/layout/components/ChatShell.tsx
+++ b/app/features/layout/components/ChatShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { CSSProperties, MouseEvent, ReactNode } from 'react';
+import { useEffect, useRef, type CSSProperties, type MouseEvent, type ReactNode } from 'react';
 
 export type ChatShellProps = {
   sidebar: ReactNode;
@@ -41,8 +41,35 @@ export function ChatShell({
   agentsSidebarOpen,
   onSidebarResizeStart,
 }: ChatShellProps) {
+  const pageRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const page = pageRef.current;
+    if (!page) return;
+
+    const visualViewport = window.visualViewport;
+    const syncViewport = () => {
+      const height = visualViewport?.height ?? window.innerHeight;
+      const offsetTop = visualViewport?.offsetTop ?? 0;
+      page.style.setProperty('--app-viewport-height', `${Math.round(height)}px`);
+      page.style.setProperty('--app-viewport-offset-top', `${Math.round(offsetTop)}px`);
+    };
+
+    syncViewport();
+    window.addEventListener('resize', syncViewport);
+    window.addEventListener('orientationchange', syncViewport);
+    visualViewport?.addEventListener('resize', syncViewport);
+    visualViewport?.addEventListener('scroll', syncViewport);
+    return () => {
+      window.removeEventListener('resize', syncViewport);
+      window.removeEventListener('orientationchange', syncViewport);
+      visualViewport?.removeEventListener('resize', syncViewport);
+      visualViewport?.removeEventListener('scroll', syncViewport);
+    };
+  }, []);
+
   return (
-    <main className="page" style={themeStyle} data-theme={themeId} suppressHydrationWarning>
+    <main ref={pageRef} className="page" style={themeStyle} data-theme={themeId} suppressHydrationWarning>
       {header}
       {mobilePanel !== null && (
         <div className="mobilePanelBackdrop" onClick={() => onMobilePanelChange(null)} />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import './features/layout/components/ChatShell.css';
 import './features/agents/components/AgentsPanel.css';
 import './features/nodes/components/NodesPanel.css';
 import './features/files/components/FileWorkspacePanel.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
 import Providers from './providers';
 
@@ -45,6 +45,12 @@ export const metadata: Metadata = {
       alt: 'Agents Chat preview',
     }],
   },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  interactiveWidget: 'resizes-content',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/tests/agent-model-ui.test.mjs
+++ b/tests/agent-model-ui.test.mjs
@@ -172,11 +172,16 @@ assert.doesNotMatch(
   'model selector must not hard-code the Aurora accent or override the target pill color',
 );
 
-// 17. Portaled dropdown CSS — fixed positioning escapes mobile overflow clipping.
+// 17. Portaled dropdown uses the themed page as its positioned containing block.
 assert.match(
   cssBlock('.agentModelDropdownPortal'),
-  /position:\s*fixed;[\s\S]*?bottom:\s*auto;/,
-  'portaled model dropdown should use fixed positioning and avoid inherited absolute bottom placement',
+  /position:\s*absolute;[\s\S]*?bottom:\s*auto;/,
+  'portaled model dropdown should use absolute positioning within the themed page',
+);
+assert.match(
+  modelSelectSource,
+  /const portalHost = wrap\.closest\('\.page'\);[\s\S]*?left:\s*viewportLeftPosition - hostRect\.left,[\s\S]*?top:\s*openAbove \? 'auto' : rect\.bottom - hostRect\.top \+ 6,[\s\S]*?bottom:\s*openAbove \? hostRect\.bottom - rect\.top \+ 6 : 'auto',/,
+  'model dropdown should convert visual viewport positions into portal-host coordinates',
 );
 
 console.log('agent model UI checks passed');

--- a/tests/mobile-composer-viewport.spec.ts
+++ b/tests/mobile-composer-viewport.spec.ts
@@ -4,8 +4,8 @@ const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
 
 async function login(page: Page) {
   await page.goto(`${BASE}/login`);
-  await page.locator('input[placeholder="Admin username"]').fill('admin');
-  await page.locator('input[placeholder="Password"]').fill('admin123');
+  await page.locator('input[placeholder="Admin username"]').fill(process.env.ADMIN_USERNAME || 'admin');
+  await page.locator('input[placeholder="Password"]').fill(process.env.ADMIN_PASSWORD || 'admin123');
   await page.locator('button[type="submit"]').click();
   await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
   await page.waitForTimeout(500);
@@ -119,6 +119,10 @@ test('keeps composer controls above iPhone browser chrome and keyboard', async (
   });
 
   await login(page);
+  await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+    'content',
+    /width=device-width.*initial-scale=1.*interactive-widget=resizes-content/,
+  );
   await page.locator('button.emptyHomepageNewChat').click();
   const textarea = page.locator('textarea.composerTextarea');
   await expect(textarea).toBeVisible({ timeout: 10000 });
@@ -150,9 +154,41 @@ test('keeps composer controls above iPhone browser chrome and keyboard', async (
   await modelButton.click();
   const modelMenu = page.getByRole('listbox', { name: 'Model for alpha' });
   await expect(modelMenu).toBeVisible();
-  const [menuTop, appTop] = await Promise.all([
-    modelMenu.evaluate((element) => element.getBoundingClientRect().top),
-    app.evaluate((element) => element.getBoundingClientRect().top),
+  const [menuRect, appRect] = await Promise.all([
+    modelMenu.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { top: rect.top, bottom: rect.bottom };
+    }),
+    app.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { top: rect.top, bottom: rect.bottom };
+    }),
   ]);
-  expect(menuTop).toBeGreaterThanOrEqual(appTop);
+  expect(menuRect.top).toBeGreaterThanOrEqual(appRect.top);
+  expect(menuRect.bottom).toBeLessThanOrEqual(appRect.bottom);
+
+  await modelButton.click();
+  await page.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: 'Chats' }).click();
+  const mobileSidebar = page.locator('.participantsSidebar');
+  const backdrop = page.locator('.mobilePanelBackdrop');
+  await expect(mobileSidebar).toBeVisible();
+  await expect(backdrop).toBeVisible();
+  for (const locator of [mobileSidebar, backdrop]) {
+    await expect.poll(() => locator.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { top: Math.round(rect.top), height: Math.round(rect.height) };
+    })).toEqual({ top: 24, height: 430 });
+  }
+  await backdrop.click({ position: { x: 420, y: 200 } });
+
+  await page.evaluate(() => {
+    (window as typeof window & { setTestVisualViewport: (height: number, offsetTop: number) => void })
+      .setTestVisualViewport(926, 0);
+  });
+  await expect.poll(() => app.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { top: Math.round(rect.top), height: Math.round(rect.height) };
+  })).toEqual({ top: 0, height: 926 });
+  await expect(sendButton).toBeVisible();
 });

--- a/tests/mobile-composer-viewport.spec.ts
+++ b/tests/mobile-composer-viewport.spec.ts
@@ -1,0 +1,158 @@
+import { expect, Page, test } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3010';
+
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.locator('input[placeholder="Admin username"]').fill('admin');
+  await page.locator('input[placeholder="Password"]').fill('admin123');
+  await page.locator('button[type="submit"]').click();
+  await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
+  await page.waitForTimeout(500);
+}
+
+test('keeps composer controls above iPhone browser chrome and keyboard', async ({ page }) => {
+  await page.setViewportSize({ width: 428, height: 926 });
+  await page.addInitScript(() => {
+    let height = 926;
+    let offsetTop = 0;
+    const listeners = new Map<string, Set<EventListener>>();
+    const visualViewport = {
+      get height() { return height; },
+      get width() { return 428; },
+      get offsetTop() { return offsetTop; },
+      get offsetLeft() { return 0; },
+      get pageTop() { return offsetTop; },
+      get pageLeft() { return 0; },
+      get scale() { return 1; },
+      addEventListener(type: string, listener: EventListener) {
+        const handlers = listeners.get(type) || new Set<EventListener>();
+        handlers.add(listener);
+        listeners.set(type, handlers);
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener);
+      },
+    };
+
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: visualViewport,
+    });
+    (window as typeof window & { setTestVisualViewport: (nextHeight: number, nextOffsetTop: number) => void })
+      .setTestVisualViewport = (nextHeight, nextOffsetTop) => {
+        height = nextHeight;
+        offsetTop = nextOffsetTop;
+        for (const listener of listeners.get('resize') || []) listener(new Event('resize'));
+        for (const listener of listeners.get('scroll') || []) listener(new Event('scroll'));
+      };
+  });
+
+  const chats = new Map<string, Record<string, unknown>>();
+  let lastChatId = '';
+  await page.route('**/api/chats**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() === 'GET') {
+      const id = url.searchParams.get('id');
+      if (id) {
+        const chat = chats.get(id);
+        await route.fulfill({
+          status: chat ? 200 : 404,
+          contentType: 'application/json',
+          body: JSON.stringify(chat ? { ok: true, chat } : { ok: false, error: 'not_found' }),
+        });
+        return;
+      }
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          chats: [...chats.values()].map((chat) => ({
+            id: chat.id,
+            name: chat.name,
+            ts: chat.ts,
+          })),
+          lastChatId,
+        }),
+      });
+      return;
+    }
+    if (request.method() === 'POST') {
+      const body = request.postDataJSON();
+      if (body?.chat) chats.set(body.chat.id, body.chat);
+      if (body?.action === 'set-last-chat') lastChatId = body.chatId || '';
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await page.route('**/api/orchestrations**', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true, items: [] }) }),
+  );
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.action === 'list-agents') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          agents: [{
+            id: 'alpha',
+            name: 'Alpha Agent',
+            command: 'mock',
+            args: [],
+            cwd: '/tmp',
+            running: true,
+            canTalk: true,
+            canModify: true,
+            public: true,
+            models: [
+              { modelId: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6' },
+              { modelId: 'gpt-5.4', name: 'GPT-5.4' },
+            ],
+            defaultModelId: 'claude-sonnet-4.6',
+          }],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await login(page);
+  await page.locator('button.emptyHomepageNewChat').click();
+  const textarea = page.locator('textarea.composerTextarea');
+  await expect(textarea).toBeVisible({ timeout: 10000 });
+  await textarea.fill('@alpha mobile viewport');
+
+  await page.evaluate(() => {
+    (window as typeof window & { setTestVisualViewport: (height: number, offsetTop: number) => void })
+      .setTestVisualViewport(430, 24);
+  });
+
+  const app = page.locator('.chatPageRoot .page');
+  await expect.poll(() => app.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { top: Math.round(rect.top), height: Math.round(rect.height) };
+  })).toEqual({ top: 24, height: 430 });
+
+  const sendButton = page.getByRole('button', { name: 'Send message' });
+  const modelButton = page.getByRole('button', { name: 'Model for alpha' });
+  await expect(sendButton).toBeVisible();
+  await expect(modelButton).toBeVisible();
+
+  for (const locator of [page.locator('.chatInputDock'), sendButton, modelButton]) {
+    const [controlBox, appBox] = await Promise.all([locator.boundingBox(), app.boundingBox()]);
+    expect(controlBox).not.toBeNull();
+    expect(appBox).not.toBeNull();
+    expect(controlBox!.y + controlBox!.height).toBeLessThanOrEqual(appBox!.y + appBox!.height + 1);
+  }
+
+  await modelButton.click();
+  const modelMenu = page.getByRole('listbox', { name: 'Model for alpha' });
+  await expect(modelMenu).toBeVisible();
+  const [menuTop, appTop] = await Promise.all([
+    modelMenu.evaluate((element) => element.getBoundingClientRect().top),
+    app.evaluate((element) => element.getBoundingClientRect().top),
+  ]);
+  expect(menuTop).toBeGreaterThanOrEqual(appTop);
+});


### PR DESCRIPTION
## Summary
- size and position the chat shell from the live Visual Viewport so iOS Chrome browser controls and the software keyboard no longer cover the composer
- keep mobile side panels and backdrops aligned with the same visible viewport
- constrain and flip the agent model menu based on available onscreen space
- request content-resizing behavior through viewport metadata

## Validation
- added an iPhone 13 Pro Max-sized regression that simulates a 430px keyboard-reduced visual viewport with a non-zero offset
- verifies the composer, send button, model selector, and model menu remain visible
- targeted mobile, orchestration, and model tests pass
- TypeScript and production build pass