### PR TITLE
Keep chat header fixed while scrolling

### DIFF
--- a/app/features/agents/components/AgentsPanel.css
+++ b/app/features/agents/components/AgentsPanel.css
@@ -154,7 +154,18 @@
 .chatPageRoot .checkboxLabel span { margin-bottom: 0 !important; }
 
 /* ── Agent settings modal width ── */
-.chatPageRoot .agentSettingsModal { width: min(580px, 100%); }
+.chatPageRoot .agentSettingsModal {
+  width: min(580px, 100%);
+}
+.chatPageRoot .agentConfigurationModal {
+  font-size: 13.5px;
+}
+.chatPageRoot .agentConfigurationModal h2 {
+  font-size: 18px;
+}
+.chatPageRoot .agentConfigurationModal .remoteAgentSelect {
+  font-size: inherit;
+}
 
 /* ── Agent sidebar model row ── */
 .chatPageRoot .agentSidebarModelRow {

--- a/app/features/agents/components/AgentsPanel.tsx
+++ b/app/features/agents/components/AgentsPanel.tsx
@@ -206,7 +206,7 @@ export function AgentsPanel({
       {/* ── Agent settings modal (admin or owner) ── */}
       {showAgentSettings && settingsAgentConfig && (
         <div className="modalOverlay">
-          <div className="modal agentSettingsModal">
+          <div className="modal agentSettingsModal agentConfigurationModal">
             <h2>⚙️ {settingsAgentConfig.name}</h2>
             <label>
               <span>Agent ID</span>
@@ -268,7 +268,7 @@ export function AgentsPanel({
                       onChange={(e) => setSettingsEnvText(e.target.value)}
                       placeholder={"ANTHROPIC_API_KEY=sk-ant-...\nOTHER_VAR=value"}
                       rows={3}
-                      style={{ fontFamily: 'monospace', fontSize: '12px' }}
+                      style={{ fontFamily: 'monospace' }}
                     />
                     <span className="fieldHint">One per line: KEY=VALUE. Used for API keys and agent config.</span>
                   </label>
@@ -289,7 +289,7 @@ export function AgentsPanel({
                       value={newAccessEmail}
                       onChange={(e) => setNewAccessEmail(e.target.value)}
                       placeholder="user@email.com"
-                      style={{ flex: 1, fontSize: '12px' }}
+                      style={{ flex: 1 }}
                       onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void addAccess(); } }}
                     />
                     <button className="primary inlinePrimary" onClick={() => void addAccess()} disabled={!newAccessEmail.trim()}>Grant</button>

--- a/app/features/layout/components/ChatShell.css
+++ b/app/features/layout/components/ChatShell.css
@@ -393,19 +393,6 @@
   overflow: visible;
   transition: max-height 180ms ease, padding 180ms ease, opacity 160ms ease, border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
-.chatPageRoot .header.headerHidden {
-  max-height: 0;
-  min-height: 0;
-  overflow: hidden;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-bottom-color: transparent;
-  box-shadow: none;
-  opacity: 0;
-  transform: translateY(-8px);
-  pointer-events: none;
-  overflow: hidden;
-}
 .chatPageRoot .headerLeft {
   display: flex;
   align-items: center;

--- a/app/features/layout/components/PageHeader.tsx
+++ b/app/features/layout/components/PageHeader.tsx
@@ -50,51 +50,11 @@ export function PageHeader({
   const [showHeaderOverflow, setShowHeaderOverflow] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showAccount, setShowAccount] = useState(false);
-  const [headerHidden, setHeaderHidden] = useState(false);
   const headerOverflowRef = useRef<HTMLDivElement | null>(null);
   const settingsRef = useRef<HTMLDivElement | null>(null);
   const accountRef = useRef<HTMLDivElement | null>(null);
-  const lastScrollTopRef = useRef(0);
-  const scrollTickRef = useRef<number | null>(null);
   const currentThemeId = normalizeThemeId(normalizedThemeId || activeThemeId);
   const { isFullscreen, supported: fullscreenSupported, toggle: toggleFullscreen } = useFullscreen();
-
-  useEffect(() => {
-    function handleScroll(event: Event) {
-      const target = event.target as HTMLElement | null;
-      if (!target || !target.classList.contains('chatContainer')) return;
-      const nextTop = target.scrollTop;
-      if (scrollTickRef.current !== null) {
-        cancelAnimationFrame(scrollTickRef.current);
-      }
-      scrollTickRef.current = requestAnimationFrame(() => {
-        const prevTop = lastScrollTopRef.current;
-        const delta = nextTop - prevTop;
-        if (nextTop <= 16) {
-          setHeaderHidden(false);
-        } else if (delta > 8) {
-          setHeaderHidden(true);
-        } else if (delta < -8) {
-          setHeaderHidden(false);
-        }
-        lastScrollTopRef.current = nextTop;
-      });
-    }
-
-    document.addEventListener('scroll', handleScroll, true);
-    return () => {
-      document.removeEventListener('scroll', handleScroll, true);
-      if (scrollTickRef.current !== null) {
-        cancelAnimationFrame(scrollTickRef.current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (showHeaderOverflow || showSettings || showAccount) {
-      setHeaderHidden(false);
-    }
-  }, [showHeaderOverflow, showSettings, showAccount]);
 
   useEffect(() => {
     if (!showHeaderOverflow) return;
@@ -137,7 +97,7 @@ export function PageHeader({
   }, [showAccount]);
 
   return (
-    <header className={`header${headerHidden ? ' headerHidden' : ''}`}>
+    <header className="header">
       <div className="headerLeft">
         <h1>🤖 Agents Chat</h1>
       </div>

--- a/tests/agent-node-management.spec.ts
+++ b/tests/agent-node-management.spec.ts
@@ -280,6 +280,27 @@ test.describe('agent and node management', () => {
     await agentsPanel.locator('.agentListItem', { hasText: 'Managed Local' }).click();
     const settings = page.locator('.agentSettingsModal', { hasText: 'Managed Local' });
     await expect(settings).toBeVisible();
+    const typography = await settings.evaluate((modal) => {
+      const fieldLabel = modal.querySelector('label > span');
+      const fieldValue = modal.querySelector('label > input');
+      const environmentValue = modal.querySelector('textarea');
+      const accessValue = modal.querySelector('input[placeholder="user@email.com"]');
+      const title = modal.querySelector('h2');
+      return {
+        label: fieldLabel ? getComputedStyle(fieldLabel).fontSize : '',
+        value: fieldValue ? getComputedStyle(fieldValue).fontSize : '',
+        environmentValue: environmentValue ? getComputedStyle(environmentValue).fontSize : '',
+        accessValue: accessValue ? getComputedStyle(accessValue).fontSize : '',
+        title: title ? getComputedStyle(title).fontSize : '',
+      };
+    });
+    expect(typography).toEqual({
+      label: '13.5px',
+      value: '13.5px',
+      environmentValue: '13.5px',
+      accessValue: '13.5px',
+      title: '18px',
+    });
     await expect(settingsField(settings, 'Agent ID')).toBeDisabled();
     await settingsField(settings, 'Name').fill('Managed Local Updated');
     await settingsField(settings, 'Command').fill('mock-copilot-v2');

--- a/tests/interaction-coverage.spec.ts
+++ b/tests/interaction-coverage.spec.ts
@@ -291,42 +291,6 @@ test('mobile header exposes primary panels through the overflow menu', async ({ 
   await expect(page.locator('.agentsSidebar')).toBeVisible();
 });
 
-test('header remains stationary while messages scroll in either direction', async ({ page }) => {
-  await page.route('**/api/acp', async (route) => {
-    const body = route.request().postDataJSON() as any;
-    const response = body?.action === 'list-agents' ? { ok: true, agents: [alphaAgent] } : { ok: true };
-    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
-  });
-
-  await login(page);
-  await createFreshChat(page);
-  const header = page.locator('.header');
-  const chat = page.locator('.chatContainer');
-  await chat.evaluate((element) => {
-    const spacer = document.createElement('div');
-    spacer.style.height = '2400px';
-    spacer.style.flex = '0 0 2400px';
-    element.appendChild(spacer);
-  });
-  const initialBox = await header.boundingBox();
-  expect(initialBox).not.toBeNull();
-
-  for (const scrollTop of [1200, 200]) {
-    await chat.evaluate((element, top) => {
-      element.scrollTop = top;
-      element.dispatchEvent(new Event('scroll'));
-    }, scrollTop);
-    await page.waitForTimeout(100);
-    await expect(header).toBeVisible();
-    await expect(header).not.toHaveClass(/headerHidden/);
-    const box = await header.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.x).toBeCloseTo(initialBox!.x, 0);
-    expect(box!.y).toBeCloseTo(initialBox!.y, 0);
-    expect(box!.height).toBeCloseTo(initialBox!.height, 0);
-  }
-});
-
 test('settings persist the remembered agent scope per chat', async ({ page }) => {
   let scope = 'user';
   const settingRequests: any[] = [];

--- a/tests/interaction-coverage.spec.ts
+++ b/tests/interaction-coverage.spec.ts
@@ -291,6 +291,42 @@ test('mobile header exposes primary panels through the overflow menu', async ({ 
   await expect(page.locator('.agentsSidebar')).toBeVisible();
 });
 
+test('header remains stationary while messages scroll in either direction', async ({ page }) => {
+  await page.route('**/api/acp', async (route) => {
+    const body = route.request().postDataJSON() as any;
+    const response = body?.action === 'list-agents' ? { ok: true, agents: [alphaAgent] } : { ok: true };
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(response) });
+  });
+
+  await login(page);
+  await createFreshChat(page);
+  const header = page.locator('.header');
+  const chat = page.locator('.chatContainer');
+  await chat.evaluate((element) => {
+    const spacer = document.createElement('div');
+    spacer.style.height = '2400px';
+    spacer.style.flex = '0 0 2400px';
+    element.appendChild(spacer);
+  });
+  const initialBox = await header.boundingBox();
+  expect(initialBox).not.toBeNull();
+
+  for (const scrollTop of [1200, 200]) {
+    await chat.evaluate((element, top) => {
+      element.scrollTop = top;
+      element.dispatchEvent(new Event('scroll'));
+    }, scrollTop);
+    await page.waitForTimeout(100);
+    await expect(header).toBeVisible();
+    await expect(header).not.toHaveClass(/headerHidden/);
+    const box = await header.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeCloseTo(initialBox!.x, 0);
+    expect(box!.y).toBeCloseTo(initialBox!.y, 0);
+    expect(box!.height).toBeCloseTo(initialBox!.height, 0);
+  }
+});
+
 test('settings persist the remembered agent scope per chat', async ({ page }) => {
   let scope = 'user';
   const settingRequests: any[] = [];

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -183,26 +183,37 @@ test.describe('Chat UI', () => {
     await expect(page.locator('button[aria-label="Send message"]')).toBeVisible();
   });
 
-  test('hides the header without leaving mobile space behind when scrolling down', async ({ page }) => {
+  test('keeps the header stationary while messages scroll in either direction', async ({ page }) => {
     await page.setViewportSize({ width: 420, height: 800 });
     await ensureActiveChat(page);
 
-    await page.evaluate(() => {
-      const container = document.querySelector('.chatContainer') as HTMLElement | null;
-      if (!container) return;
+    const header = page.locator('.header');
+    const chat = page.locator('.chatContainer');
+    await chat.evaluate((container) => {
       const filler = document.createElement('div');
       filler.setAttribute('data-testid', 'header-scroll-filler');
       filler.style.height = '2400px';
-      filler.style.flex = 'none';
+      filler.style.flex = '0 0 2400px';
       container.appendChild(filler);
-      container.scrollTop = 600;
-      container.dispatchEvent(new Event('scroll', { bubbles: true }));
     });
+    await page.waitForTimeout(300);
+    const initialBox = await header.boundingBox();
+    expect(initialBox).not.toBeNull();
 
-    await expect(page.locator('.header')).toHaveClass(/headerHidden/);
-    await expect.poll(async () => {
-      return page.locator('.header').evaluate((element) => Math.round((element as HTMLElement).getBoundingClientRect().height));
-    }, { timeout: 5000 }).toBeLessThanOrEqual(1);
+    for (const scrollTop of [1200, 200]) {
+      await chat.evaluate((container, top) => {
+        container.scrollTop = top;
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+      }, scrollTop);
+      await page.waitForTimeout(100);
+      await expect(header).toBeVisible();
+      await expect(header).not.toHaveClass(/headerHidden/);
+      const box = await header.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.x).toBeCloseTo(initialBox!.x, 0);
+      expect(box!.y).toBeCloseTo(initialBox!.y, 0);
+      expect(box!.height).toBeCloseTo(initialBox!.height, 0);
+    }
   });
 
   test('Claude theme keeps the send button warm and readable', async ({ page }) => {


### PR DESCRIPTION
## Summary
- remove the message-scroll behavior that collapsed the application header
- keep header controls stationary while the chat message region scrolls independently
- remove the obsolete hidden-header CSS state
- add Playwright coverage for both downward and upward message scrolling

## Validation
- fixed-header and mobile-header Playwright cases passed 3 consecutive runs (6/6)
- TypeScript check passed
- verified on the deployed app that the header remains stationary