### PR TITLE
Preserve user messages across stale chat saves

### DIFF
--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
-import { listChats, getChat, saveChat, deleteChat, renameChat, migrateFromJson, getLastChatId, setLastChatId, StoredChat, deleteOrchestrationsForChat, searchChats } from '@/lib/chatStore';
+import { listChats, getChat, mergeChat, deleteChat, renameChat, migrateFromJson, getLastChatId, setLastChatId, StoredChat, deleteOrchestrationsForChat, searchChats } from '@/lib/chatStore';
 
 export const dynamic = 'force-dynamic';
 
@@ -80,7 +80,7 @@ export async function POST(req: NextRequest) {
   // Ensure agentSessions is present
   if (!chat.agentSessions) chat.agentSessions = {};
 
-  await saveChat(userId, chat);
+  await mergeChat(userId, chat);
   return NextResponse.json({ ok: true });
 }
 

--- a/lib/chatStore.ts
+++ b/lib/chatStore.ts
@@ -258,6 +258,27 @@ export async function saveChat(userId: string, chat: StoredChat): Promise<void> 
   saveChatWithDb(db, userId, chat);
 }
 
+export function mergeStoredMessages(existing: StoredMessage[], incoming: StoredMessage[]): StoredMessage[] {
+  const merged = new Map(
+    existing
+      .filter(message => message.type === 'user')
+      .map(message => [message.id, message]),
+  );
+  for (const message of incoming) merged.set(message.id, message);
+  return [...merged.values()].sort((a, b) => a.ts - b.ts);
+}
+
+export async function mergeChat(userId: string, chat: StoredChat): Promise<void> {
+  const db = getDb();
+  const merge = db.transaction(() => {
+    const existing = getChatWithDb(db, userId, chat.id);
+    saveChatWithDb(db, userId, existing
+      ? { ...chat, messages: mergeStoredMessages(existing.messages, chat.messages) }
+      : chat);
+  });
+  merge();
+}
+
 function mapStoredChatRow(row: any): StoredChat {
   return {
     id: row.chat_id,

--- a/tests/mobile-composer-viewport.spec.ts
+++ b/tests/mobile-composer-viewport.spec.ts
@@ -154,18 +154,19 @@ test('keeps composer controls above iPhone browser chrome and keyboard', async (
   await modelButton.click();
   const modelMenu = page.getByRole('listbox', { name: 'Model for alpha' });
   await expect(modelMenu).toBeVisible();
-  const [menuRect, appRect] = await Promise.all([
-    modelMenu.evaluate((element) => {
-      const rect = element.getBoundingClientRect();
-      return { top: rect.top, bottom: rect.bottom };
-    }),
-    app.evaluate((element) => {
-      const rect = element.getBoundingClientRect();
-      return { top: rect.top, bottom: rect.bottom };
-    }),
-  ]);
-  expect(menuRect.top).toBeGreaterThanOrEqual(appRect.top);
-  expect(menuRect.bottom).toBeLessThanOrEqual(appRect.bottom);
+  await expect.poll(async () => {
+    const [menuRect, appRect] = await Promise.all([
+      modelMenu.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return { top: rect.top, bottom: rect.bottom };
+      }),
+      app.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return { top: rect.top, bottom: rect.bottom };
+      }),
+    ]);
+    return menuRect.top >= appRect.top && menuRect.bottom <= appRect.bottom;
+  }).toBe(true);
 
   await modelButton.click();
   await page.getByRole('button', { name: 'More actions' }).click();

--- a/tests/test-file-comments.spec.ts
+++ b/tests/test-file-comments.spec.ts
@@ -15,9 +15,15 @@ const ADMIN_PASS = 'admin123';
 
 async function login(page: Page) {
   await page.goto(`${BASE}/login`);
-  await page.fill('input[placeholder="Admin username"]', ADMIN_USER);
-  await page.fill('input[placeholder="Password"]', ADMIN_PASS);
-  await page.click('button[type="submit"]');
+  const usernameInput = page.locator('input[placeholder="Admin username"]');
+  const passwordInput = page.locator('input[placeholder="Password"]');
+  const submitButton = page.locator('button[type="submit"]');
+  await expect(async () => {
+    await usernameInput.fill(ADMIN_USER);
+    await passwordInput.fill(ADMIN_PASS);
+    await expect(submitButton).toBeEnabled({ timeout: 1000 });
+  }).toPass({ timeout: 10000 });
+  await submitButton.click();
   await page.waitForSelector('.chatContainer, .emptyHomepage', { timeout: 30000 });
   const isEmpty = await page.locator('.emptyHomepage').isVisible({ timeout: 2000 }).catch(() => false);
   if (isEmpty) {

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -2172,6 +2172,51 @@ test.describe('Chat UI', () => {
     console.log('PASS: Messages persisted in SQLite and survived page reload');
   });
 
+  test('should preserve messages when a stale browser saves the same chat', async ({ page }) => {
+    const chatId = `multi-client-save-${Date.now()}`;
+    const userMessage = {
+      id: `${chatId}-user`,
+      type: 'user',
+      content: 'message from the active browser',
+      ts: Date.now(),
+    };
+    const agentMessage = {
+      id: `${chatId}-agent`,
+      type: 'agent',
+      content: 'reply completed in another browser',
+      agentId: 'alpha',
+      ts: userMessage.ts + 1,
+    };
+
+    try {
+      const result = await page.evaluate(async ({ id, user, agent }) => {
+        const save = (messages: unknown[]) => fetch('/api/chats', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chat: { id, name: 'Multi-client persistence', ts: Date.now(), messages, agentSessions: {} },
+          }),
+        });
+
+        await save([user]);
+        await save([agent]);
+        const staleSaveResponse = await fetch(`/api/chats?id=${encodeURIComponent(id)}`);
+        const afterStaleSave = await staleSaveResponse.json();
+        await save([user]);
+        const removalResponse = await fetch(`/api/chats?id=${encodeURIComponent(id)}`);
+        return { afterStaleSave, afterRemoval: await removalResponse.json() };
+      }, { id: chatId, user: userMessage, agent: agentMessage });
+
+      expect(result.afterStaleSave.ok).toBe(true);
+      expect(result.afterStaleSave.chat.messages).toEqual(expect.arrayContaining([userMessage, agentMessage]));
+      expect(result.afterRemoval.chat.messages).toEqual([userMessage]);
+    } finally {
+      await page.evaluate(async (id) => {
+        await fetch(`/api/chats?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+      }, chatId);
+    }
+  });
+
   test('should show share button', async ({ page }) => {
     // The share button should exist for chat history items
     const shareBtn = page.locator('.chatShareBtn').first();


### PR DESCRIPTION
## Summary
- preserve previously stored user messages when an older browser or tab saves a stale full-chat snapshot
- keep agent and system messages authoritative to the incoming snapshot so removed temporary messages do not reappear
- perform the read/merge/write in one SQLite transaction
- add a Playwright regression covering both stale multi-client saves and normal agent-message removal

## Validation
- `npx tsc --noEmit`
- `npx playwright test tests/test-ui.spec.ts --grep "persist messages to SQLite|preserve messages when a stale browser" --workers=1` (2 passed)

## Note
The production SQLite recovery was an operational data repair and is not part of this PR.