### PR TITLE
feat(chat): convert system messages to transient notifications

### DIFF
--- a/app/features/messages/components/MessageList.css
+++ b/app/features/messages/components/MessageList.css
@@ -1,4 +1,43 @@
 /* ── Message bubble ── */
+.chatToastStack {
+  position: fixed;
+  top: 72px;
+  right: 16px;
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(460px, calc(100vw - 24px));
+  pointer-events: none;
+}
+.chatToast {
+  align-self: flex-end;
+  padding: 10px 12px;
+  border-radius: 11px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-left: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--panel-strong) 82%, var(--accent-soft));
+  color: var(--text);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+  font-size: 12.5px;
+  line-height: 1.4;
+  animation: chatToastInOut 3.6s ease forwards;
+}
+@keyframes chatToastInOut {
+  0% {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  12%, 76% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+}
+
 .message {
   max-width: 80%;
   padding: 14px 16px;

--- a/app/features/messages/components/MessageList.tsx
+++ b/app/features/messages/components/MessageList.tsx
@@ -28,13 +28,49 @@ export function MessageList({
   onAnswerAgentUserRequest: (requestId: string, response: AgentUserRequestResponse) => Promise<void>;
   onDismissAgentUserRequest: (requestId: string) => void;
 }) {
+  const [toasts, setToasts] = useState<Array<{ id: string; text: string }>>([]);
   const [mounted, setMounted] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [copiedFormattedMessageId, setCopiedFormattedMessageId] = useState<string | null>(null);
+  const seenSystemMessageIdsRef = useRef<Set<string>>(new Set());
+  const toastTimeoutsRef = useRef<Record<string, number>>({});
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    return () => {
+      for (const timeoutId of Object.values(toastTimeoutsRef.current)) {
+        window.clearTimeout(timeoutId);
+      }
+      toastTimeoutsRef.current = {};
+    };
+  }, []);
+
+  useEffect(() => {
+    const now = Date.now();
+    for (const message of messages) {
+      if (message.type !== 'system') continue;
+      if (message.id === 'welcome') continue;
+      if (seenSystemMessageIdsRef.current.has(message.id)) continue;
+      seenSystemMessageIdsRef.current.add(message.id);
+      if (typeof message.ts === 'number' && now - message.ts > 15000) continue;
+
+      const toastText = (message.content || '').replace(/^✅\s*/, '').trim();
+      if (!toastText) continue;
+
+      const toastId = `toast-${message.id}`;
+      setToasts((prev) => [...prev, { id: toastId, text: toastText }]);
+      const timeoutId = window.setTimeout(() => {
+        setToasts((prev) => prev.filter((toast) => toast.id !== toastId));
+        delete toastTimeoutsRef.current[toastId];
+      }, 3600);
+      toastTimeoutsRef.current[toastId] = timeoutId;
+    }
+  }, [messages]);
+
+  const chatMessages = useMemo(() => messages.filter((message) => message.type !== 'system'), [messages]);
 
   const messagesById = useMemo(() => {
     const map = new Map<string, ChatMessage>();
@@ -96,7 +132,14 @@ export function MessageList({
 
   return (
     <>
-      {messages.map((message) => (
+      {toasts.length > 0 ? (
+        <div className="chatToastStack" aria-live="polite" aria-atomic="false">
+          {toasts.map((toast) => (
+            <div key={toast.id} className="chatToast" role="status">{toast.text}</div>
+          ))}
+        </div>
+      ) : null}
+      {chatMessages.map((message) => (
         <MessageBubble
           key={message.id}
           message={message}

--- a/tests/test-ui.spec.ts
+++ b/tests/test-ui.spec.ts
@@ -1545,7 +1545,7 @@ test.describe('Chat UI', () => {
     await expect.poll(() => sendCalls, { timeout: 10000 }).toBe(1);
 
     await page.click('button.newChatButton');
-    await expect(chatArea.locator('.message.system', { hasText: 'New chat "New Chat" created.' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.chatToast', { hasText: 'New chat "New Chat" created.' })).toBeVisible({ timeout: 10000 });
     releaseFailure();
     await expect(chatArea.locator('.message.user', { hasText: failedText })).toHaveCount(0);
 
@@ -1926,8 +1926,8 @@ test.describe('Chat UI', () => {
     await page.click('button.newChatButton');
     await page.waitForSelector('.chatContainer', { timeout: 10000 });
 
-    // Should show welcome message in the new empty chat
-    await expect(page.locator('text=Welcome to Agents Chat')).toBeVisible();
+    // Should show transient creation notification
+    await expect(page.locator('.chatToast', { hasText: 'New chat "New Chat" created.' })).toBeVisible({ timeout: 10000 });
 
     // Chat input should be empty and ready
     const textarea = page.locator('textarea.composerTextarea');
@@ -2005,9 +2005,8 @@ test.describe('Chat UI', () => {
 
     // Step 2: Switch to a new chat and wait for it to fully initialize
     await page.click('button.newChatButton');
-    await expect(chatArea.locator('text=Welcome to Agents Chat')).toBeVisible();
     // Wait for createNewChat() to finish creating agent sessions
-    await expect(chatArea.locator('.message.system:has-text("created")')).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('.chatToast', { hasText: 'New chat "New Chat" created.' })).toBeVisible({ timeout: 30000 });
 
     // Step 3: Switch back to the old chat
     const oldChat = page.locator('.chatHistoryItem', { hasText: 'Let a = 1 + 1' });
@@ -4683,7 +4682,7 @@ test.describe('Empty Homepage', () => {
   test('should create chat from empty homepage button', async ({ page }) => {
     await page.click('button.emptyHomepageNewChat');
     await page.waitForSelector('.chatContainer', { timeout: 10000 });
-    await expect(page.locator('text=Welcome to Agents Chat')).toBeVisible();
+    await expect(page.locator('.chatToast', { hasText: 'New chat "New Chat" created.' })).toBeVisible({ timeout: 10000 });
     // Empty homepage should be gone
     await expect(page.locator('.emptyHomepage')).not.toBeVisible();
   });
@@ -4691,7 +4690,7 @@ test.describe('Empty Homepage', () => {
   test('should create chat from sidebar New Chat button on empty homepage', async ({ page }) => {
     await page.click('button.newChatButton');
     await page.waitForSelector('.chatContainer', { timeout: 10000 });
-    await expect(page.locator('text=Welcome to Agents Chat')).toBeVisible();
+    await expect(page.locator('.chatToast', { hasText: 'New chat "New Chat" created.' })).toBeVisible({ timeout: 10000 });
   });
 });
 


### PR DESCRIPTION
## Summary
- render non-welcome system messages as transient toast notifications instead of chat bubbles
- hide system messages from the main chat message list to avoid confusion with model replies
- update Playwright UI expectations from system bubble text to toast visibility

## Testing
- get_errors on changed files: no errors
- npx playwright test --config tests/playwright.config.ts tests/test-ui.spec.ts -g "should create a new chat" *(fails in this environment before test execution because Playwright browser binaries are missing; run `npx playwright install` first)*
